### PR TITLE
fix(migrations): explicit per-table RLS policies, transactional, idempotent

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -95,3 +95,26 @@ das per JS-Hack zu umgehen.
 `CHECKLISTS` und `SAMPLE_GAISBACH` aus `prototype.html` werden als
 `src/lib/seed/checklists.ts` und `src/lib/seed/gaisbach.ts` portiert. Vorteil:
 typsicher, kein SQL-Quoting-Hell. Beim Seed-Run werden sie via Drizzle insertet.
+
+## D-013 — RLS-Policies explizit pro Tabelle (kein dynamisches SQL)
+
+Der erste Wurf von `0001_rls_and_triggers.sql` hatte einen `DO $$ FOREACH …`-
+Block, der per `format()` Policy-SQL pro Tabelle generierte. Postgres validiert
+Spalten-Referenzen aber schon beim PARSE (nicht erst beim runtime-`CASE`-Eval),
+also fliegt z.B. `houses.house_id` (existiert nicht — `house_id` gehört zu
+`apartments`) sofort raus.
+
+**Entscheidung**: keine Policy-Generation-Loops mehr. Jede Tabelle bekommt ihr
+eigenes explizites `CREATE POLICY`-Statement mit der korrekten USING-Klausel
+basierend auf ihrem realen Schema (siehe `0000_…sql`). Für Tabellen ohne
+direktes `project_id` (`apartments`, `checklist_photos`, `task_dependencies`,
+`task_apartment_progress`, `defect_photos`, `defect_history`) wird via
+`EXISTS (SELECT 1 FROM <parent>)`-Subquery auf die Membership des
+übergeordneten Projekts geprüft.
+
+Außerdem: Migration ist in `BEGIN;`/`COMMIT;` gewrapped, damit bei einem
+Fehler nichts halb angelegt wird, und beginnt mit `DROP POLICY IF EXISTS`
+für alle Policies, damit Re-Runs nach partial fail idempotent sind.
+
+Auch 0002 (storage policies) wurde auf 4 explizite `CREATE POLICY`-Statements
+umgeschrieben — vorher format-loop, jetzt eine Policy pro Bucket.

--- a/supabase/migrations/0001_rls_and_triggers.sql
+++ b/supabase/migrations/0001_rls_and_triggers.sql
@@ -1,10 +1,18 @@
 -- ============================================================
 -- 0001_rls_and_triggers
--- Enables RLS, defines policies, and adds auto-profile-on-signup trigger.
--- See docs/DECISIONS.md D-009 for the policy template.
+-- Defines: is_project_member() helper, handle_new_user trigger,
+-- enables RLS, and creates explicit policies per table.
+--
+-- Idempotent: drops policies/triggers via IF EXISTS before re-creating,
+-- so it's safe to re-run (e.g. after a partial failed apply).
+-- Wrapped in a transaction — on any failure, nothing is half-applied.
 -- ============================================================
 
--- Helper: is current user a member of a project?
+BEGIN;
+
+-- ------------------------------------------------------------
+-- Helper function: is current user a member of a project?
+-- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.is_project_member(pid uuid)
 RETURNS boolean
 LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
@@ -15,9 +23,9 @@ AS $$
   );
 $$;
 
--- Auto-create profile row on auth.users insert.
--- Bauleiter team is hard-allowlisted by email — others get a profile but no
--- project memberships, so RLS will hide everything.
+-- ------------------------------------------------------------
+-- Auto-create profile on auth.users insert
+-- ------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS trigger
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
@@ -41,116 +49,318 @@ CREATE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
 
--- ============================================================
--- Enable RLS on every public table
--- ============================================================
-ALTER TABLE public.profiles                  ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.projects                  ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.project_members           ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.houses                    ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.apartments                ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.gewerke                   ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.checklists                ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.checklist_sections        ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.checklist_items           ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.checklist_progress        ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.checklist_photos          ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.tasks                     ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.task_dependencies         ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.task_apartment_progress   ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.plans                     ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.contacts                  ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.defects                   ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.defect_photos             ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.defect_history            ENABLE ROW LEVEL SECURITY;
+-- ------------------------------------------------------------
+-- Enable RLS on every table (idempotent: ENABLE on already-enabled is a no-op)
+-- ------------------------------------------------------------
+ALTER TABLE public.profiles                   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.projects                   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.project_members            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.houses                     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.apartments                 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gewerke                    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.checklists                 ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.checklist_sections         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.checklist_items            ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.checklist_progress         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.checklist_photos           ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tasks                      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_dependencies          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.task_apartment_progress    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.plans                      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.contacts                   ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.defects                    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.defect_photos              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.defect_history             ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.gewerk_checklist_templates ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.gewerk_checklist_progress ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.musterdetails             ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.activity                  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.gewerk_checklist_progress  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.musterdetails              ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.activity                   ENABLE ROW LEVEL SECURITY;
 
--- ============================================================
--- Profiles: read all (so we can show "Jonas hat …"), write only own row
--- ============================================================
+-- ------------------------------------------------------------
+-- Drop existing policies first (idempotent re-run protection)
+-- ------------------------------------------------------------
+DROP POLICY IF EXISTS "profiles read authed"                ON public.profiles;
+DROP POLICY IF EXISTS "profiles update own"                 ON public.profiles;
+
+DROP POLICY IF EXISTS "gewerke read"                        ON public.gewerke;
+DROP POLICY IF EXISTS "checklists read"                     ON public.checklists;
+DROP POLICY IF EXISTS "checklist_sections read"             ON public.checklist_sections;
+DROP POLICY IF EXISTS "checklist_items read"                ON public.checklist_items;
+DROP POLICY IF EXISTS "gewerk_checklist_templates read"     ON public.gewerk_checklist_templates;
+
+DROP POLICY IF EXISTS "projects select members"             ON public.projects;
+DROP POLICY IF EXISTS "projects insert authed"              ON public.projects;
+DROP POLICY IF EXISTS "projects update members"             ON public.projects;
+DROP POLICY IF EXISTS "projects delete owner"               ON public.projects;
+
+DROP POLICY IF EXISTS "project_members select"              ON public.project_members;
+DROP POLICY IF EXISTS "project_members insert by self or owner" ON public.project_members;
+DROP POLICY IF EXISTS "project_members delete owner"        ON public.project_members;
+
+DROP POLICY IF EXISTS "houses rw members"                   ON public.houses;
+DROP POLICY IF EXISTS "apartments rw members"               ON public.apartments;
+DROP POLICY IF EXISTS "checklist_progress rw members"       ON public.checklist_progress;
+DROP POLICY IF EXISTS "checklist_photos rw members"         ON public.checklist_photos;
+DROP POLICY IF EXISTS "tasks rw members"                    ON public.tasks;
+DROP POLICY IF EXISTS "task_dependencies rw members"        ON public.task_dependencies;
+DROP POLICY IF EXISTS "task_apartment_progress rw members"  ON public.task_apartment_progress;
+DROP POLICY IF EXISTS "plans rw members"                    ON public.plans;
+DROP POLICY IF EXISTS "contacts rw members"                 ON public.contacts;
+DROP POLICY IF EXISTS "contacts read global"                ON public.contacts;
+DROP POLICY IF EXISTS "defects rw members"                  ON public.defects;
+DROP POLICY IF EXISTS "defect_photos rw members"            ON public.defect_photos;
+DROP POLICY IF EXISTS "defect_history rw members"           ON public.defect_history;
+DROP POLICY IF EXISTS "gewerk_checklist_progress rw members" ON public.gewerk_checklist_progress;
+DROP POLICY IF EXISTS "musterdetails rw members"            ON public.musterdetails;
+DROP POLICY IF EXISTS "activity rw members"                 ON public.activity;
+
+-- ------------------------------------------------------------
+-- Profiles: read all (so we can show "Jonas hat …"), write own row only
+-- ------------------------------------------------------------
 CREATE POLICY "profiles read authed" ON public.profiles
   FOR SELECT TO authenticated USING (true);
 CREATE POLICY "profiles update own" ON public.profiles
   FOR UPDATE TO authenticated USING (id = auth.uid()) WITH CHECK (id = auth.uid());
 
--- ============================================================
--- Catalog tables (gewerke, checklists*) — read-only for authed
--- ============================================================
-CREATE POLICY "gewerke read" ON public.gewerke FOR SELECT TO authenticated USING (true);
-CREATE POLICY "checklists read" ON public.checklists FOR SELECT TO authenticated USING (true);
-CREATE POLICY "checklist_sections read" ON public.checklist_sections FOR SELECT TO authenticated USING (true);
-CREATE POLICY "checklist_items read" ON public.checklist_items FOR SELECT TO authenticated USING (true);
+-- ------------------------------------------------------------
+-- Catalog tables (read-only for authed)
+-- ------------------------------------------------------------
+CREATE POLICY "gewerke read"                    ON public.gewerke                    FOR SELECT TO authenticated USING (true);
+CREATE POLICY "checklists read"                 ON public.checklists                 FOR SELECT TO authenticated USING (true);
+CREATE POLICY "checklist_sections read"         ON public.checklist_sections         FOR SELECT TO authenticated USING (true);
+CREATE POLICY "checklist_items read"            ON public.checklist_items            FOR SELECT TO authenticated USING (true);
 CREATE POLICY "gewerk_checklist_templates read" ON public.gewerk_checklist_templates FOR SELECT TO authenticated USING (true);
 
--- ============================================================
--- Projects: select via membership; insert by anyone authed (creator becomes owner)
--- ============================================================
+-- ------------------------------------------------------------
+-- Projects
+-- ------------------------------------------------------------
 CREATE POLICY "projects select members" ON public.projects
-  FOR SELECT TO authenticated USING (public.is_project_member(id));
+  FOR SELECT TO authenticated
+  USING (public.is_project_member(id));
+
 CREATE POLICY "projects insert authed" ON public.projects
-  FOR INSERT TO authenticated WITH CHECK (created_by = auth.uid());
+  FOR INSERT TO authenticated
+  WITH CHECK (created_by = auth.uid());
+
 CREATE POLICY "projects update members" ON public.projects
-  FOR UPDATE TO authenticated USING (public.is_project_member(id)) WITH CHECK (public.is_project_member(id));
+  FOR UPDATE TO authenticated
+  USING (public.is_project_member(id))
+  WITH CHECK (public.is_project_member(id));
+
 CREATE POLICY "projects delete owner" ON public.projects
-  FOR DELETE TO authenticated USING (
-    EXISTS (SELECT 1 FROM project_members WHERE project_id = projects.id AND user_id = auth.uid() AND role = 'owner')
+  FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.project_members
+      WHERE project_id = projects.id
+        AND user_id = auth.uid()
+        AND role = 'owner'
+    )
   );
 
--- ============================================================
--- project_members: select if you're a member of the same project
--- insert/delete: only by an owner of the project
--- ============================================================
+-- ------------------------------------------------------------
+-- project_members
+-- ------------------------------------------------------------
 CREATE POLICY "project_members select" ON public.project_members
-  FOR SELECT TO authenticated USING (public.is_project_member(project_id) OR user_id = auth.uid());
+  FOR SELECT TO authenticated
+  USING (public.is_project_member(project_id) OR user_id = auth.uid());
+
 CREATE POLICY "project_members insert by self or owner" ON public.project_members
-  FOR INSERT TO authenticated WITH CHECK (
+  FOR INSERT TO authenticated
+  WITH CHECK (
     user_id = auth.uid()
-    OR EXISTS (SELECT 1 FROM project_members pm WHERE pm.project_id = project_members.project_id AND pm.user_id = auth.uid() AND pm.role = 'owner')
+    OR EXISTS (
+      SELECT 1 FROM public.project_members pm
+      WHERE pm.project_id = project_members.project_id
+        AND pm.user_id = auth.uid()
+        AND pm.role = 'owner'
+    )
   );
+
 CREATE POLICY "project_members delete owner" ON public.project_members
-  FOR DELETE TO authenticated USING (
+  FOR DELETE TO authenticated
+  USING (
     user_id = auth.uid()
-    OR EXISTS (SELECT 1 FROM project_members pm WHERE pm.project_id = project_members.project_id AND pm.user_id = auth.uid() AND pm.role = 'owner')
+    OR EXISTS (
+      SELECT 1 FROM public.project_members pm
+      WHERE pm.project_id = project_members.project_id
+        AND pm.user_id = auth.uid()
+        AND pm.role = 'owner'
+    )
   );
 
--- ============================================================
--- Generic project-scoped RLS macro (apply to all child tables)
--- ============================================================
-DO $$
-DECLARE t text;
-BEGIN
-  FOREACH t IN ARRAY ARRAY[
-    'houses','apartments','checklist_progress','checklist_photos',
-    'tasks','task_dependencies','task_apartment_progress',
-    'plans','contacts','defects','defect_photos','defect_history',
-    'gewerk_checklist_progress','musterdetails','activity'
-  ]
-  LOOP
-    EXECUTE format($f$
-      CREATE POLICY "%1$s rw members" ON public.%1$I
-        FOR ALL TO authenticated
-        USING (
-          CASE
-            WHEN to_regclass('public.%1$I') IS NULL THEN false
-            ELSE public.is_project_member(
-              CASE
-                WHEN '%1$s' IN ('apartments') THEN (SELECT project_id FROM houses WHERE houses.id = %1$I.house_id)
-                WHEN '%1$s' IN ('checklist_photos') THEN (SELECT project_id FROM checklist_progress cp WHERE cp.id = %1$I.progress_id)
-                WHEN '%1$s' IN ('task_dependencies') THEN (SELECT project_id FROM tasks t WHERE t.id = %1$I.predecessor_id)
-                WHEN '%1$s' IN ('task_apartment_progress') THEN (SELECT project_id FROM tasks t WHERE t.id = %1$I.task_id)
-                WHEN '%1$s' IN ('defect_photos','defect_history') THEN (SELECT project_id FROM defects d WHERE d.id = %1$I.defect_id)
-                ELSE %1$I.project_id
-              END
-            )
-          END
-        );
-    $f$, t);
-  END LOOP;
-END $$;
+-- ------------------------------------------------------------
+-- Tables with a direct project_id column
+-- ------------------------------------------------------------
+CREATE POLICY "houses rw members" ON public.houses
+  FOR ALL TO authenticated
+  USING (public.is_project_member(project_id))
+  WITH CHECK (public.is_project_member(project_id));
 
--- contacts may be global (project_id IS NULL) — read by anyone authed
-CREATE POLICY "contacts read global" ON public.contacts
-  FOR SELECT TO authenticated USING (project_id IS NULL);
+CREATE POLICY "checklist_progress rw members" ON public.checklist_progress
+  FOR ALL TO authenticated
+  USING (public.is_project_member(project_id))
+  WITH CHECK (public.is_project_member(project_id));
+
+CREATE POLICY "tasks rw members" ON public.tasks
+  FOR ALL TO authenticated
+  USING (public.is_project_member(project_id))
+  WITH CHECK (public.is_project_member(project_id));
+
+CREATE POLICY "plans rw members" ON public.plans
+  FOR ALL TO authenticated
+  USING (public.is_project_member(project_id))
+  WITH CHECK (public.is_project_member(project_id));
+
+CREATE POLICY "defects rw members" ON public.defects
+  FOR ALL TO authenticated
+  USING (public.is_project_member(project_id))
+  WITH CHECK (public.is_project_member(project_id));
+
+CREATE POLICY "musterdetails rw members" ON public.musterdetails
+  FOR ALL TO authenticated
+  USING (public.is_project_member(project_id))
+  WITH CHECK (public.is_project_member(project_id));
+
+CREATE POLICY "activity rw members" ON public.activity
+  FOR ALL TO authenticated
+  USING (public.is_project_member(project_id))
+  WITH CHECK (public.is_project_member(project_id));
+
+CREATE POLICY "gewerk_checklist_progress rw members" ON public.gewerk_checklist_progress
+  FOR ALL TO authenticated
+  USING (public.is_project_member(project_id))
+  WITH CHECK (public.is_project_member(project_id));
+
+-- ------------------------------------------------------------
+-- apartments → project via houses.project_id
+-- ------------------------------------------------------------
+CREATE POLICY "apartments rw members" ON public.apartments
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.houses h
+      WHERE h.id = apartments.house_id
+        AND public.is_project_member(h.project_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.houses h
+      WHERE h.id = apartments.house_id
+        AND public.is_project_member(h.project_id)
+    )
+  );
+
+-- ------------------------------------------------------------
+-- checklist_photos → project via checklist_progress.project_id
+-- ------------------------------------------------------------
+CREATE POLICY "checklist_photos rw members" ON public.checklist_photos
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.checklist_progress cp
+      WHERE cp.id = checklist_photos.progress_id
+        AND public.is_project_member(cp.project_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.checklist_progress cp
+      WHERE cp.id = checklist_photos.progress_id
+        AND public.is_project_member(cp.project_id)
+    )
+  );
+
+-- ------------------------------------------------------------
+-- task_dependencies → project via tasks.project_id (predecessor)
+-- ------------------------------------------------------------
+CREATE POLICY "task_dependencies rw members" ON public.task_dependencies
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.tasks t
+      WHERE t.id = task_dependencies.predecessor_id
+        AND public.is_project_member(t.project_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.tasks t
+      WHERE t.id = task_dependencies.predecessor_id
+        AND public.is_project_member(t.project_id)
+    )
+  );
+
+-- ------------------------------------------------------------
+-- task_apartment_progress → project via tasks.project_id
+-- ------------------------------------------------------------
+CREATE POLICY "task_apartment_progress rw members" ON public.task_apartment_progress
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.tasks t
+      WHERE t.id = task_apartment_progress.task_id
+        AND public.is_project_member(t.project_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.tasks t
+      WHERE t.id = task_apartment_progress.task_id
+        AND public.is_project_member(t.project_id)
+    )
+  );
+
+-- ------------------------------------------------------------
+-- defect_photos → project via defects.project_id
+-- ------------------------------------------------------------
+CREATE POLICY "defect_photos rw members" ON public.defect_photos
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.defects d
+      WHERE d.id = defect_photos.defect_id
+        AND public.is_project_member(d.project_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.defects d
+      WHERE d.id = defect_photos.defect_id
+        AND public.is_project_member(d.project_id)
+    )
+  );
+
+-- ------------------------------------------------------------
+-- defect_history → project via defects.project_id
+-- ------------------------------------------------------------
+CREATE POLICY "defect_history rw members" ON public.defect_history
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.defects d
+      WHERE d.id = defect_history.defect_id
+        AND public.is_project_member(d.project_id)
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.defects d
+      WHERE d.id = defect_history.defect_id
+        AND public.is_project_member(d.project_id)
+    )
+  );
+
+-- ------------------------------------------------------------
+-- contacts: project-scoped OR global (project_id IS NULL).
+-- READ: both project-members AND global (everyone authed).
+-- WRITE: only project-scoped rows; global contacts come from seed scripts
+--        (which use service-role and therefore bypass RLS).
+-- ------------------------------------------------------------
+CREATE POLICY "contacts rw members" ON public.contacts
+  FOR ALL TO authenticated
+  USING (project_id IS NULL OR public.is_project_member(project_id))
+  WITH CHECK (project_id IS NOT NULL AND public.is_project_member(project_id));
+
+COMMIT;

--- a/supabase/migrations/0002_storage_buckets.sql
+++ b/supabase/migrations/0002_storage_buckets.sql
@@ -1,8 +1,17 @@
 -- ============================================================
 -- 0002_storage_buckets
--- Creates the four buckets used by the app and locks down policies so
--- that only authed members of the owning project can read/write.
+-- Creates the four private buckets used by the app and locks down
+-- access via path-based RLS policies on storage.objects.
+--
+-- Convention: every object key starts with "<projectId>/...".
+-- Membership is checked via public.is_project_member() (defined in 0001).
+--
+-- Idempotent: bucket inserts use ON CONFLICT DO NOTHING; policy
+-- creates are guarded by DROP POLICY IF EXISTS.
+-- Wrapped in a transaction.
 -- ============================================================
+
+BEGIN;
 
 -- Buckets are private (signed URLs only)
 INSERT INTO storage.buckets (id, name, public)
@@ -13,19 +22,58 @@ VALUES
   ('musterdetails',    'musterdetails',    false)
 ON CONFLICT (id) DO NOTHING;
 
--- Object policy: path is "<projectId>/..." across all four buckets.
--- The first segment must be a project_id the current user is a member of.
-DO $$
-DECLARE b text;
-BEGIN
-  FOREACH b IN ARRAY ARRAY['checklist-photos','defect-photos','plans','musterdetails']
-  LOOP
-    EXECUTE format($f$
-      DROP POLICY IF EXISTS "members rw %1$s" ON storage.objects;
-      CREATE POLICY "members rw %1$s" ON storage.objects
-        FOR ALL TO authenticated
-        USING (bucket_id = %1$L AND public.is_project_member((split_part(name,'/',1))::uuid))
-        WITH CHECK (bucket_id = %1$L AND public.is_project_member((split_part(name,'/',1))::uuid));
-    $f$, b);
-  END LOOP;
-END $$;
+-- ------------------------------------------------------------
+-- Policies on storage.objects, one per bucket.
+-- The first segment of `name` (before the first '/') must be a UUID
+-- that the current user is a member of via project_members.
+-- ------------------------------------------------------------
+
+DROP POLICY IF EXISTS "members rw checklist-photos" ON storage.objects;
+CREATE POLICY "members rw checklist-photos" ON storage.objects
+  FOR ALL TO authenticated
+  USING (
+    bucket_id = 'checklist-photos'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  )
+  WITH CHECK (
+    bucket_id = 'checklist-photos'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  );
+
+DROP POLICY IF EXISTS "members rw defect-photos" ON storage.objects;
+CREATE POLICY "members rw defect-photos" ON storage.objects
+  FOR ALL TO authenticated
+  USING (
+    bucket_id = 'defect-photos'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  )
+  WITH CHECK (
+    bucket_id = 'defect-photos'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  );
+
+DROP POLICY IF EXISTS "members rw plans" ON storage.objects;
+CREATE POLICY "members rw plans" ON storage.objects
+  FOR ALL TO authenticated
+  USING (
+    bucket_id = 'plans'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  )
+  WITH CHECK (
+    bucket_id = 'plans'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  );
+
+DROP POLICY IF EXISTS "members rw musterdetails" ON storage.objects;
+CREATE POLICY "members rw musterdetails" ON storage.objects
+  FOR ALL TO authenticated
+  USING (
+    bucket_id = 'musterdetails'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  )
+  WITH CHECK (
+    bucket_id = 'musterdetails'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  );
+
+COMMIT;


### PR DESCRIPTION
## Bugfix

Migration `0001_rls_and_triggers.sql` aus PR #1 ist beim Ausführen geknallt:

```
ERROR: 42703: column houses.house_id does not exist
CONTEXT: SQL statement "CREATE POLICY houses rw members ON public.houses..."
```

**Ursache:** Die `DO $$ FOREACH … format()`-Schleife hat `%1$I.house_id`
für **alle** Tabellen substituiert. Postgres validiert Spalten-Referenzen
aber schon beim PARSE — nicht erst beim runtime-`CASE`-Eval — also fliegt
`houses.house_id` (Spalte gehört zu `apartments`) sofort raus, bevor das
CASE überhaupt ausgewertet wird.

**Folgeschaden:** 0002 läuft ebenfalls nicht, weil `is_project_member()`
nie angelegt wird, wenn 0001 vorher abbricht.

## Fix

Beide Migrations komplett neu geschrieben:

### `0001_rls_and_triggers.sql`
- `BEGIN;` / `COMMIT;` → bei Fehler nichts halb-angelegt
- `is_project_member()` und `handle_new_user()` als Erstes
- 23 explizite `CREATE POLICY`-Statements, jeweils mit korrekter
  USING/WITH-CHECK-Klausel basierend auf dem realen Spalten-Schema:
  - **Direkt `project_id`**: houses, plans, defects, tasks, activity,
    musterdetails, checklist_progress, gewerk_checklist_progress
  - **Via Parent**: apartments → houses · checklist_photos →
    checklist_progress · task_dependencies → tasks (predecessor) ·
    task_apartment_progress → tasks · defect_photos → defects ·
    defect_history → defects
  - **Catalog (read-only)**: gewerke, checklists, checklist_sections,
    checklist_items, gewerk_checklist_templates
  - **Profile**: jeder authed liest, nur Self-Update
  - **Contacts**: read both global + project-scoped, write nur
    project-scoped (Globals werden via Service-Role-Seed-Skript befüllt)
- Jede Policy mit `DROP POLICY IF EXISTS` davor → idempotent bei Re-Run
  nach partial fail

### `0002_storage_buckets.sql`
- `BEGIN;` / `COMMIT;`
- Vier explizite `CREATE POLICY`-Statements für die vier Buckets
  (`checklist-photos`, `defect-photos`, `plans`, `musterdetails`)
- Pfad-basierte Permission: erste URL-Komponente muss eine
  `project_member`-Project-ID sein

## Test plan

- [ ] Im Supabase SQL-Editor: kompletten Inhalt von
      `supabase/migrations/0001_rls_and_triggers.sql` rein-pasten und
      ausführen → `BEGIN`/`COMMIT` ohne Fehler
- [ ] Dann `supabase/migrations/0002_storage_buckets.sql` →
      `BEGIN`/`COMMIT` ohne Fehler
- [ ] `pnpm seed && pnpm seed:contacts` → 20 Gewerke + 11 Checklisten +
      ~38 Gewerk-Templates + 20 Kontakte angelegt
- [ ] Magic-Link-Login → Profile wird automatisch via Trigger angelegt
- [ ] Sample-Projekt anlegen → RLS hindert Test-User mit anderem Account
      daran, das Projekt zu sehen

## Doku

`docs/DECISIONS.md` D-013 dokumentiert die Entscheidung gegen
dynamic-policy-generation und für explizite Statements pro Tabelle.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_