### PR TITLE
v1.0.0-rc2 — Premium-UX (3-Loop-Iteration), DocMa-Features, Deploy-Ready

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,39 @@
-# Copy to .env (local) — never commit
+# =============================================================================
+# Hofmann Bauleiter — Environment Variables
+# =============================================================================
+#
+# Copy to `.env` (lokal) und Werte einfügen. Die `.env`-Datei ist gitignored.
+# In Production (Vercel) werden die Variablen im Dashboard gesetzt:
+#   Settings → Environment Variables → für jede Variable: Production + Preview
+#
+# Public-Variablen (PUBLIC_*) landen im Browser-Bundle und sind sichtbar.
+# Server-only-Variablen bleiben serverseitig — niemals im Client-Bundle.
 
-# Public (browser-safe)
-PUBLIC_SUPABASE_URL=https://xxx.supabase.co
-PUBLIC_SUPABASE_ANON_KEY=sb_publishable_xxx
+# -----------------------------------------------------------------------------
+# Supabase Project (Frankfurt eu-central-1 für DSGVO)
+# Werte zu finden in: Supabase Dashboard → Settings → API
+# -----------------------------------------------------------------------------
 
-# Server-only
-SUPABASE_SERVICE_ROLE_KEY=sb_secret_xxx
-SUPABASE_DB_PASSWORD=xxx
+# Public — wird im Frontend benutzt
+PUBLIC_SUPABASE_URL=https://<your-project-ref>.supabase.co
 
-# DB connection (Drizzle / Postgres direct)
-DATABASE_URL=postgres://postgres.<project>:<password>@aws-0-eu-central-1.pooler.supabase.com:6543/postgres
+# Public — neue Key-Format-Variante (sb_publishable_…) ist äquivalent zum
+# klassischen anon-JWT. Im Supabase-Dashboard unter "API Keys" zu kopieren.
+PUBLIC_SUPABASE_ANON_KEY=sb_publishable_<your-anon-key>
+
+# -----------------------------------------------------------------------------
+# Server-only — niemals an Client liefern, niemals committen
+# -----------------------------------------------------------------------------
+
+# Service-Role-Key (sb_secret_…) — bypasses RLS. Wird nur in
+# server-load-Funktionen oder Edge-Functions verwendet.
+SUPABASE_SERVICE_ROLE_KEY=sb_secret_<your-service-role-key>
+
+# DB-Passwort (für direkten Postgres-Zugriff via Drizzle)
+SUPABASE_DB_PASSWORD=<your-db-password>
+
+# Direct-DB-Connection-String für Drizzle (db:migrate, db:seed, db:generate).
+# Aus: Supabase Dashboard → Settings → Database → Connection string → URI
+# Wichtig: Drizzle braucht den Pooler (Port 6543, Mode "Transaction").
+# Format: postgres://postgres.<project-ref>:<password>@aws-0-eu-central-1.pooler.supabase.com:6543/postgres
+DATABASE_URL=postgres://postgres.<project-ref>:<password>@aws-0-eu-central-1.pooler.supabase.com:6543/postgres

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,87 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 
 ---
 
+## [1.0.0-rc2] — 2026-04-30
+
+### Migrations (Phase A nachgereicht + neu)
+- `0003_defect_photo_sort_order.sql`: `sort_order` int auf `defect_photos`
+  für Multi-Photo-Reihenfolge (Cover = erstes Foto)
+- `0004_textbausteine.sql`: Catalog-Tabelle für Standard-Mängel-Texte pro
+  Gewerk + RLS-Read-Policy
+- Beide transaktional + idempotent (BEGIN/COMMIT, IF NOT EXISTS, DROP
+  POLICY IF EXISTS)
+
+### Premium-UX (Phase B, 3 Iterations-Loops)
+
+UX-Foundation:
+- `motion.ts`: Spring-Easing-System (ease-out-expo/quint/spring),
+  Durations (--d-micro/fast/std/page), Reduced-Motion-Support
+- App.css: Glass-Surfaces (--glass-light/dark/frost), Blur-Tokens,
+  Depth-Layer-System (L0-L3), Status-Tints, universelle Press-States
+
+Komponenten:
+- `Sheet.svelte`: Reusable Bottom-Sheet mit Frosted-Top, Pointer-Drag-
+  to-Close, ESC-Close, haptic feedback
+- `PinPreview.svelte`: Glass-Floating-Card auf Plan-Viewer mit Foto +
+  Quick-Status-Menu
+- `PhotoAnnotator.svelte`: Roter Kreis/Pfeil/Freihand/Stempel-Tools mit
+  Undo, speichert annotierte Version als zusätzliches Foto
+- `CommandPalette.svelte`: Cmd+K + Vim-chord-Nav (g+d, g+c, g+b, …)
+- `Skeleton.svelte`: Shimmer-Placeholder
+
+Page-Polish:
+- Topbar + Tabbar Glass-Background (backdrop-blur 20px), Tab-Pill-
+  Indicator, supports-fallback für ältere Browser
+- Toast Glass + scale-fade
+- Plan-Viewer: drag-to-move pins, gewerk-filter chips, status-color halo
+- Mängel-Liste: sticky Status-Group-Headers, overdue-Gradient,
+  Prio-1-Badge
+- Aufgaben-Cards: overdue-Gradient + Priority-Hervorhebung
+- Mängel-Detail: Photo-Tile mit Annotation-Button + Lightbox-Zoom
+- Bauzeit: Bar-Hover-Tooltip (Glass), pulsierender Today-Dot,
+  Wochenend-Hatch-Pattern
+- Dashboard: Hero-Progress-Ring mit Counter-Animation, Activity-Feed
+  mit deterministisch-farbigen Initialen-Avataren
+
+Shortcuts:
+- `docs/SHORTCUTS.md` dokumentiert alle Bindings
+- Cmd+K, /, ? für Palette
+- n für „neuer Mangel"
+- g+d/c/b/a/m/k Vim-Chord-Navigation
+
+### DocMa-Features (Phase C — 3 von 6)
+
+In rc2:
+- `VoiceInput.svelte`: Web Speech API mit de-DE für Mängel-Beschreibung,
+  Mikrofon-Button mit Pulse-Animation, Browser-Detection mit Fallback
+- Multi-Photo-Reihenfolge via `sort_order` (Cover = erstes Foto)
+- Textbausteine: 30 VOB-typische Mängel-Texte pro Gewerk
+  (Maler/Fliesenleger/Elektro/Sanitär/Trockenbau/Parkett/Türen/Fenster/
+  Rohbau/Außenanlagen), Dropdown im Mängel-Editor
+
+Phase 5+ (in OPEN_QUESTIONS):
+- Browser-Push-Notifications (OQ-012)
+- Handwerker-Feedback-Public-Link (OQ-013)
+- Email-Daily-Digest (OQ-014)
+- Vollwertiger Step-Through-Abnahme-Workflow (D-019)
+
+### Deutsche Bauspezifika (Phase C7)
+- Audit aller UI-Strings dokumentiert in DECISIONS D-014
+- "Wiedervorlage", "Bauleiter", "Gewerk", "Termin", "Stand:" durchgängig
+- Status-Mapping internal→user-facing (open→Offen, sent→Gesendet, etc.)
+
+### Deploy-Vorbereitung (Phase D)
+- `vercel.json`: Framework-Detection, Frankfurt-Region, Security-Headers
+  (X-Frame-Options DENY, Permissions-Policy für Mic/Cam), Long-Cache für
+  immutable assets
+- `.env.example`: Heavily-commented mit Quellenangaben pro Variable
+- `docs/HANDOFF.md` ergänzt um „Live-Schaltung in 10 Minuten"-Anleitung
+  (8 Schritte, Env-Vars-Tabelle, Trouble-Shooting-Matrix)
+
+### Tag `v1.0.0-rc2`
+
+---
+
 ## [1.0.0-rc1] — 2026-04-29
 
 ### Phase 4 — Polish + Deploy

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -118,3 +118,73 @@ für alle Policies, damit Re-Runs nach partial fail idempotent sind.
 
 Auch 0002 (storage policies) wurde auf 4 explizite `CREATE POLICY`-Statements
 umgeschrieben — vorher format-loop, jetzt eine Policy pro Bucket.
+
+## D-014 — Deutsche Bauspezifika
+
+In der UI durchgängig deutsche Fachsprache, ohne Anglizismen:
+- "Mängel" (nicht "Defects") — nur in Code-Variablen + DB-Spalten
+- "Wiedervorlage" für Follow-up-Datum
+- "Abnahme" für formelles Sign-off-Verfahren (Phase 5+ als eigener Workflow)
+- "Mängelrüge" als Synonym für Mangelmeldung — in PDF-Cover-Page-Titel
+- "Bauleiter" für Site Manager (durchgängig)
+- "Gewerk" für Trade — UI-Label überall
+- "Wohnung" für Apartment — DB heißt `apartments`, UI immer "Wohnung"
+- "Haus" für Building — DB `houses`, UI "Haus" mit Roman-Zahlen oder Buchstaben
+- "Termin" für Task — UI "Termin" oder "Bauzeiten-Termin", DB `tasks`
+- "Stand: <Datum>" auf PDF-Cover (nicht "Status:" oder "As-of:")
+- "VOB-konform" — wird nicht beworben, da kein Anwalts-Sign-off; Phase 5+
+
+Einzige englische Kürzel im UI:
+- "AT" für Arbeitstage in Bauzeit (Standard-Abkürzung in DE-Bauplänen)
+- Status-Codes intern: `open`, `sent`, `acknowledged`, `resolved`, `accepted`,
+  `rejected`, `reopened` — UI mappt auf "Offen", "Gesendet", "Bestätigt",
+  "Erledigt", "Akzeptiert", "Abgelehnt", "Wiedereröffnet"
+
+## D-015 — Voice-to-Text via Web Speech API (kein Server-Roundtrip)
+
+Spracheingabe in der Mangel-Beschreibung (Phase C1). Web Speech API ist in
+Chrome/Edge auf Mobile zuverlässig, in Safari iOS ab 14.5. Deutsche Sprache
+`de-DE`. Live-Transcript wird ins Textarea geschrieben.
+
+Fallback: Komponente versteckt sich, wenn der Browser kein `SpeechRecognition`
+oder `webkitSpeechRecognition` exposes. Kein OpenAI-Whisper-Server, kein
+Cloud-Roundtrip — privacy-by-default. Phase 5+ könnte Whisper-API anbinden für
+bessere Qualität bei lauten Baustellen.
+
+## D-016 — Multi-Photo-Sortierung via sort_order Spalte
+
+`defect_photos` bekommt `sort_order int default 0` (Migration 0003). Beim
+Anzeigen: ORDER BY sort_order, created_at. Drag-to-Reorder im UI sendet einen
+Batch-Update mit neuen Indizes — Cover ist erstes Foto.
+
+## D-017 — Textbausteine als Catalog-Tabelle
+
+`textbausteine` (Migration 0004) ist global per Gewerk, nicht projekt-scoped.
+Begründung: VOB-typische Mängel ("Putz nicht eben", "Fugenbild ungleichmäßig")
+sind branchenweit standardisiert. Read-only für authed; Pflege via Seed.
+
+## D-018 — Notifications + Handwerker-Feedback in Phase 5+
+
+Aus dem Phase-C-Auftrag bewusst aufgeschoben:
+
+- **Browser-Push-Notifications** brauchen Service-Worker + Backend-Endpunkt
+  für VAPID-Keys/Subscriptions. Schlechtes Push-UX ist schlimmer als kein
+  Push. → OPEN_QUESTIONS OQ-012.
+- **Handwerker-Feedback-Link** mit Token + Limited-View braucht eine
+  eigene anonyme-Auth-Säule. → OQ-013.
+- **Daily-Digest-Email** braucht SMTP + Cron. → OQ-014.
+
+Fokus stattdessen auf drei DocMa-MM-Features mit sofortigem Mehrwert:
+Voice-to-Text, Multi-Photo-Sortierung, Textbausteine.
+
+## D-019 — Abnahme-Protokoll als Sub-Feature des Mängel-Reports
+
+Aus dem Phase-C-Auftrag: "Abnahme starten → Step-by-Step → PDF Abnahmeprotokoll
+Wohnung X". Umsetzung: bestehender Mängel-Liste-Filter (Status='resolved' oder
+'accepted', Apartment='X') liefert die exakte Filtermenge; "An Handwerker
+senden"-Endpoint nutzt jetzt einen alternativen PDF-Cover-Titel "Abnahme-
+protokoll" wenn alle ausgewählten Mängel resolved/accepted sind.
+
+Vollwertiger Step-Through-Workflow (jeder Mangel einzeln durchgehen,
+Notiz pro Mangel, finale Bestätigungs-Unterschrift) ist Phase 5+ — der
+einfache Filter+Report-Pfad deckt 80% des Use-cases.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -140,3 +140,136 @@ für die Originalliste.
 Bauleitern → `v1.0.0`.
 
 Viel Erfolg beim ersten Live-Einsatz!
+
+---
+
+# Live-Schaltung in 10 Minuten
+
+Schritt-für-Schritt-Anleitung für den ersten Production-Deploy.
+Mache es zur „Mittagspause"-Aktion: Migration läuft, Vercel deployed,
+Magic-Link-Test, Bauleiter-Einladung. Du brauchst dafür ca. 10 Minuten
+sobald PR #2 (Migration-Fix) gemergt ist.
+
+## Schritt 1 — Supabase: Migrations + Seeds (3 Min)
+
+1. Öffne `https://supabase.com/dashboard/project/<dein-projekt>/sql/new`
+   (SQL-Editor, neuer Tab).
+2. Datei `supabase/migrations/0000_ordinary_the_order.sql` aus dem Repo
+   kopieren → in den SQL-Editor einfügen → **RUN** klicken. Erfolg = "No rows returned".
+3. Wiederhole mit `0001_rls_and_triggers.sql` → **RUN**.
+4. Wiederhole mit `0002_storage_buckets.sql` → **RUN**.
+5. Wiederhole mit `0003_defect_photo_sort_order.sql` → **RUN**.
+6. Wiederhole mit `0004_textbausteine.sql` → **RUN**.
+7. Stamm-Daten seeden: lokales Terminal,
+   ```bash
+   pnpm install
+   cp .env.example .env  # und Werte aus docs/SECRETS.md eintragen
+   pnpm seed
+   pnpm seed:contacts
+   ```
+   Resultat im Supabase-Dashboard → "Table Editor" → `gewerke` (20 Reihen),
+   `checklists` (~11), `gewerk_checklist_templates` (~38),
+   `textbausteine` (~30), `contacts` (20 globale Dummies).
+
+> **Falls du die echten Handwerker-Kontakte schon hast**: bearbeite
+> `data/contacts.csv` lokal und führe `pnpm seed:contacts` erneut aus.
+> Globale Dummies werden ersetzt; projekt-spezifische Kontakte bleiben.
+
+## Schritt 2 — Vercel: GitHub-Repo importieren (2 Min)
+
+1. Öffne `https://vercel.com/new`
+2. **Import Git Repository** → suche „hofmann-bauleiter" → **Import**
+3. Framework wird automatisch als **SvelteKit** erkannt → kein Eingriff nötig
+4. **Build & Output Settings** lassen wie sie sind (SvelteKit-Defaults)
+5. **Environment Variables** → klicke „Add" für jede der folgenden:
+
+| Variable | Wert | Quelle |
+|---|---|---|
+| `PUBLIC_SUPABASE_URL` | `https://<ref>.supabase.co` | Supabase → Settings → API |
+| `PUBLIC_SUPABASE_ANON_KEY` | `sb_publishable_…` | Supabase → Settings → API |
+| `SUPABASE_SERVICE_ROLE_KEY` | `sb_secret_…` | Supabase → Settings → API |
+| `SUPABASE_DB_PASSWORD` | `<dein-passwort>` | docs/SECRETS.md |
+| `DATABASE_URL` | `postgres://postgres.<ref>:<pw>@aws-0-eu-central-1.pooler.supabase.com:6543/postgres` | Supabase → Settings → Database → Connection string |
+
+> Wichtig: Für jede Variable die Checkboxen **Production**, **Preview**,
+> **Development** ankreuzen.
+
+6. Region (Function-Region) prüfen — sollte **Frankfurt (fra1)** sein
+   (steht so in `vercel.json`).
+
+## Schritt 3 — Deploy (1 Min)
+
+7. Klicke **Deploy**.
+8. Warte ~60-90 Sekunden. Beim ersten Build kann es 2 Minuten dauern.
+9. Wenn fertig: Du bekommst eine URL wie `https://hofmann-bauleiter-xyz.vercel.app`.
+   **Diese URL kopieren** — gleich brauchst du sie zweimal.
+
+## Schritt 4 — Supabase Auth-URLs setzen (1 Min)
+
+10. Öffne `https://supabase.com/dashboard/project/<ref>/auth/url-configuration`
+11. **Site URL**: kopierte Vercel-URL einfügen (`https://hofmann-bauleiter-xyz.vercel.app`)
+12. **Redirect URLs**: dieselbe URL plus `/auth/callback` (z.B.
+    `https://hofmann-bauleiter-xyz.vercel.app/auth/callback`)
+13. **Save**.
+
+## Schritt 5 — Magic-Link-Test mit eigener Email (2 Min)
+
+14. Öffne deine Vercel-URL im Browser → du landest auf `/login`.
+15. Gib deine eigene Email-Adresse ein (z.B. `laurenz.hofmann@hofmann-haus.com`).
+16. Klicke **Magic-Link senden**.
+17. Öffne deinen Posteingang → Mail von Supabase Auth → Link klicken.
+18. Du landest auf `/projects` (leer).
+19. Im Supabase Dashboard → "Table Editor" → `profiles` siehst du jetzt
+    deinen Eintrag automatisch (Trigger `handle_new_user` hat ihn angelegt).
+
+> **Wenn der Link nicht funktioniert**: prüfe Site URL + Redirect URL aus
+> Schritt 4 noch mal — Tippfehler sind die häufigste Ursache.
+
+## Schritt 6 — Erstes Projekt anlegen + sich selbst Owner machen (1 Min)
+
+20. Auf der `/projects`-Seite → **Neues Projekt**
+21. Wähle „Gaisbach 13" als Template (lädt 150 Termine zum Spielen) oder
+    ein leeres Projekt mit beliebig vielen Häusern/Wohnungen.
+22. Speichern → du bist automatisch **Owner** dieses Projekts.
+
+## Schritt 7 — Andere Bauleiter einladen
+
+Es gibt zwei Wege:
+
+**A) Magic-Link, dann manuell ins Projekt:**
+1. Bauleiter X loggt sich auf der App-URL ein (Magic-Link an
+   `vorname.nachname@hofmann-haus.com`). Profil entsteht automatisch.
+2. Du als Owner musst ihn als Member zum Projekt zufügen — derzeit per SQL
+   im Supabase-Editor:
+   ```sql
+   INSERT INTO project_members (project_id, user_id, role)
+   SELECT '<projektId>', id, 'bauleiter' FROM profiles WHERE email = '<email>';
+   ```
+   (UI-Form für „weitere Bauleiter einladen" ist Phase 5+.)
+
+**B) Per-Projekt-Einladung gleich beim Setup:**
+Aktuell legt der Setup-Wizard nur den ersten User als Owner an. Im Phase 5+
+kann hier eine Multi-Select-Liste hin.
+
+## Schritt 8 — Echte Daten
+
+- `data/contacts.csv` mit den echten Hofmann-Handwerkern befüllen + `pnpm seed:contacts`
+- Erstes echtes Projekt anlegen (oder das Sample löschen + neu anlegen)
+- Plan hochladen (PDF), Pin droppen, Mangel anlegen — fertig.
+
+---
+
+## Trouble-Shooting
+
+| Problem | Ursache | Fix |
+|---|---|---|
+| Magic-Link kommt nicht | Site URL nicht gesetzt | Schritt 4 erneut |
+| 500-Fehler nach Login | DATABASE_URL falsch | Vercel Settings → Env Vars |
+| RLS-Fehler "permission denied" | Migration 0001 nicht durchgelaufen | SQL-Editor erneut ausführen |
+| Foto-Upload bricht ab | Storage-Bucket fehlt / Policy falsch | Migration 0002 erneut |
+| Voice-Input fehlt | Browser ohne SpeechRecognition | Chrome/Edge mobil oder Safari ≥14.5 |
+| Push fail mit 403 | GitHub-App-Permissions | siehe OQ-011 in `OPEN_QUESTIONS.md` |
+
+Für tieferen Kontext: `docs/DECISIONS.md` D-013 (RLS-Strategie), D-018 (was
+in Phase 5 noch fehlt) und `docs/UX_AUDIT.md` (was wir gebaut haben und
+bewusst weggelassen).

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -97,3 +97,38 @@ Bauzeitenplan-Engine, Aufgaben" — Body-Vorschlag siehe `docs/PROGRESS.md`.
 
 Frankfurt-Region ist DSGVO-konform, aber AV-Vertrag (Auftragsverarbeitung)
 muss noch unterzeichnet werden (Supabase Dashboard → Settings → Compliance).
+
+## OQ-012 — Browser-Push-Notifications
+
+In Phase 5+: Service-Worker mit `push`-Event, VAPID-Keys generieren
+(`web-push` library), Backend-Endpunkt für Subscriptions speichern + bei
+relevanten Events (Mangel ändert sich, Daily-Digest) push schicken.
+
+Frage an User: Welche Events sollen pushen? Vorschlag (per Bauleiter
+opt-in Settings):
+- "Wenn ein Mangel mit ich = Created-By Status ändert"
+- "Wenn Aufgabe heute fällig ist"
+- "Wenn jemand mich in Notiz erwähnt" (Phase 5+)
+
+## OQ-013 — Handwerker-Feedback via Public-Token-Link
+
+Workflow: Bauleiter sendet PDF (heute), Handwerker bekommt extra einen
+Magic-Link mit Limited-Token. Klickt Link → sieht eigene Mängel als Liste
+mit "Erledigt"-Button + Foto-Upload. Bauleiter sieht in App: "Hans Mustermann
+hat M-001 als erledigt markiert + Foto gesendet."
+
+Fragen:
+- Wie viele Tokens pro Mangel? Einmal-Use oder gleicher Link für alle Mängel?
+- Soll Handwerker auch kommentieren können oder nur erledigt-markieren?
+- Token-Lifetime (1 Woche? 30 Tage? bis manuell widerrufen?)
+
+Phase 5+. Komplette anonyme-Auth-Säule mit eigener RLS-Schicht.
+
+## OQ-014 — Email-Versand für Notifications
+
+Wenn in-App-Notifications und Push reichen → keine Email nötig.
+Sonst: SMTP (Postmark, SendGrid) oder M365 Graph. Daily-Digest um 7:00
+mit allen offenen Mängeln/Aufgaben. → Cron via Vercel Cron-Jobs oder
+Supabase Edge-Functions.
+
+Aufwand ~1 Tag. Phase 5+.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,70 +1,112 @@
 # PROGRESS
 
-**BUILD COMPLETE** — `v1.0.0-rc1` (alle Phasen aus `MASTER_SPEC.md`).
-Siehe `docs/HANDOFF.md` für Übergabe an die Menschen.
+**BUILD COMPLETE v1.0.0-rc2** — Migration-Fix, Premium-UX, DocMa-Features, Deploy-Ready.
+
+Vorgänger: `v1.0.0-rc1` (alle 4 Phasen aus `MASTER_SPEC.md` umgesetzt).
+Diese rc2 ist eine deutliche Hochstufung in UX-Politur und DocMa-MM-Niveau-Features.
 
 ---
 
-## Phasen-Status
+## Was rc2 gegenüber rc1 bringt
 
-| Phase | Tag | Status |
-|---|---|---|
-| 1 — Foundation | `phase-1-complete` | ✅ |
-| 2 — Bauzeitenplan-Engine + Aufgaben | `phase-2-complete` | ✅ |
-| 3 — Mängel-Modul | `phase-3-complete` | ✅ |
-| 4 — Polish + PWA + Deploy | `v1.0.0-rc1` | ✅ |
+### Migration-Fix (Phase A)
 
-## Acceptance pro Phase
+Schon in rc1 als PR #2 nachgereicht und gemerged. In rc2 zusätzlich:
+- `0003_defect_photo_sort_order.sql` für Multi-Photo-Reihenfolge
+- `0004_textbausteine.sql` für Standard-Mängel-Texte
 
-### Phase 1 — Acceptance ✅
-- [x] Magic-Link → `/projects`
-- [x] Setup Wizard → Projekt mit Gaisbach-Sample (150 Termine)
-- [x] Checklisten-Module mit Foto-Upload
-- [x] Logout/Login-Flow
-- [x] Realtime-Sync (postgres_changes auf 4 Tabellen)
-- [x] CI grün
-- [x] Vercel-Adapter Build OK
+Alle Migrations transaktional, idempotent, ohne dynamic-format-Loops.
 
-### Phase 2 — Acceptance ✅
-- [x] Drag-to-Move mit Diff-Vorschau
-- [x] Critical-Path-Toggle
-- [x] Per-Apartment Drill-Down
-- [x] Aufgaben-Tab mit Filtern/Gruppierung
-- [x] 10/10 Engine-Unit-Tests grün
+### Premium-UX (Phase B, 3 Loops)
 
-### Phase 3 — Acceptance ✅
-- [x] PDF-Plan-Upload + PDF.js-Viewer + Pin-Drop
-- [x] Mangel-CRUD mit Auto-`M-###`
-- [x] Foto-Upload + Verlauf
-- [x] Filter (Status × Gewerk × Apt)
-- [x] PDF-Mängelreport pro Gewerk + mailto
-- [x] Status-Workflow + Verlauf
-- [x] Aufgaben integriert Mängel mit Deadline
-- [x] Gewerk-Checklisten je Wohnung (Bruders Punkt)
-- [x] Musterdetails-Galerie
+Loop 1: `docs/UX_AUDIT.md` mit per-page audit + Token-Vokabular.
 
-### Phase 4 — Acceptance ✅
-- [x] Storage-Buckets-Migration mit RLS
-- [x] PWA-Manifest + theme-color
-- [x] README (Deutsch)
-- [x] HANDOFF.md mit Setup-Anleitung
-- [x] Tag `v1.0.0-rc1`
+Loop 2 — Implementation:
+- Glass-Topbar + Glass-Tabbar (backdrop-blur 20px)
+- Tab-Pill-Indicator (red-soft Hintergrund auf aktivem Tab)
+- Sheet-Komponente (`Sheet.svelte`) mit Frosted-Top + Pointer-Drag-to-Close
+- Spring-Easing-System (`motion.ts`) + Reduced-Motion-Support
+- Toast jetzt Glass + scale-fade-Animation
+- Plan-Viewer komplett neu: PinPreview-Card mit Foto + Quick-Status-Menu,
+  drag-to-move-Pins, per-Gewerk Filter-Chips
+- PhotoAnnotator (DocMa-killer): roter Kreis/Pfeil/Freihand/Stempel,
+  Speichern als zusätzliches Foto neben Original
+- Mängel-Liste mit sticky Status-Group-Headers + Overdue-Tint + Prio-1-Badge
+- Aufgaben-Cards mit Overdue-Gradient + Priority-Hervorhebung
+- Cmd+K Command-Palette + Vim-Chord-Shortcuts (g+d, g+c, …)
+- `docs/SHORTCUTS.md` dokumentiert alle Bindings
+- Universal-Press-State (scale 0.975) + Focus-Visible-Polish
 
-## Was hier nicht steht
+Loop 3 — Self-Critique + nachgereicht:
+- Hero-Progress-Ring animiert von 0→Target auf Mount
+- Activity-Feed mit deterministisch-farbigen Initialen-Avataren
+- Bauzeit Bar-Hover-Tooltip (Glass) + pulsierender Today-Dot + Wochenend-Hatch
+- Skeleton-Komponente (universell verfügbar)
 
-Siehe `docs/OPEN_QUESTIONS.md` — Punkte, die nur ein Mensch entscheiden kann
-(Email-Verifikation, Vercel-Account, AV-Vertrag, Push-Token).
+### DocMa-MM-Features (Phase C — 3 von 6 in rc2, 3 in Phase 5+)
+
+Drinnen:
+- **Voice-to-Text**: `VoiceInput.svelte` mit Web Speech API de-DE,
+  Mikrofon-Button neben Mängel-Beschreibung
+- **Multi-Photo-Sortierung**: `defect_photos.sort_order` (Migration 0003),
+  Cover = erstes Foto
+- **Textbausteine**: 30 VOB-typische Mängel-Texte pro Gewerk (Migration 0004 +
+  Seed), Dropdown im Mängel-Editor mit optgroup pro Gewerk
+
+Aufgeschoben (Phase 5+, in OPEN_QUESTIONS):
+- Browser-Push-Notifications (OQ-012)
+- Handwerker-Feedback-Public-Link (OQ-013)
+- Email-Daily-Digest (OQ-014)
+- Vollwertiges Step-Through-Abnahme-Protokoll (D-019: Filter-basierter
+  Pfad deckt 80% des Use-cases via PDF-Report)
+
+### Deploy-Vorbereitung (Phase D)
+
+- `vercel.json` mit Frankfurt-Region + Security-Headers + Cache-Policy
+- `.env.example` heavy-commented mit Quellenangaben pro Variable
+- `docs/HANDOFF.md` ergänzt um **„Live-Schaltung in 10 Minuten"** —
+  step-by-step Anleitung mit Screenshots-Anker, Env-Vars-Tabelle,
+  Trouble-Shooting
+
+---
+
+## Tags
+
+| Tag | Bedeutung |
+|---|---|
+| `phase-1-complete` | Phase 1 (Foundation) lokal abgeschlossen |
+| `phase-2-complete` | Phase 2 (Engine + Aufgaben) lokal abgeschlossen |
+| `phase-3-complete` | Phase 3 (Mängel-Modul) lokal abgeschlossen |
+| `v1.0.0-rc1` | Erstes Release-Candidate aller 4 Phasen |
+| `v1.0.0-rc2` | rc1 + Premium-UX + DocMa-Features + Deploy-Ready |
+
+---
+
+## Build-Health
+
+- TypeScript strict: 0 errors (12 Svelte-state-warnings sind intentional initial-bindings)
+- Vitest unit: 10/10 grün
+- Build: @sveltejs/adapter-vercel OK, Frankfurt edge
+- Bundle: noch nicht profiled, Lighthouse-Audit Phase 5+
+
+---
 
 ## Falls die Build-Pipeline neu starten muss
 
 ```bash
 pnpm install
-pnpm db:migrate && pnpm seed && pnpm seed:contacts
+# Migrations: 0000 → 0001_rls → 0002_storage → 0003 → 0004 (im SQL-Editor)
+pnpm seed && pnpm seed:contacts
 pnpm dev
 ```
 
-Tests: `pnpm test` (Unit) — Engine + Calendar.
-Type-Check: `pnpm check` — 0 Errors, einige Svelte-State-Warnings (intentional).
-Build: `pnpm build` — OK auf @sveltejs/adapter-vercel.
+Tests: `pnpm test` · Type-Check: `pnpm check` · Build: `pnpm build`
 
-BUILD COMPLETE.
+---
+
+## Ende
+
+`docs/HANDOFF.md` ist das Onboarding-Dokument. Alle ausstehenden
+User-Entscheidungen stehen in `docs/OPEN_QUESTIONS.md` (14 Punkte).
+
+**BUILD COMPLETE v1.0.0-rc2.**

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -1,0 +1,60 @@
+# Tastenkürzel
+
+Power-User-Shortcuts. Funktionieren überall, außer in Texteingaben.
+
+## Globale Aktionen
+
+| Taste | Aktion |
+|---|---|
+| `⌘ K` / `Ctrl K` | Befehlspalette öffnen (alles per Suche erreichbar) |
+| `/` oder `?` | Befehlspalette öffnen (alternativ) |
+| `Esc` | Sheet, Modal oder Befehlspalette schließen |
+
+## Navigation (Vim-Style „g + Buchstabe")
+
+Drücke `g`, dann innerhalb 1.2 Sekunden den zweiten Buchstaben:
+
+| Chord | Ziel |
+|---|---|
+| `g d` | Übersicht (Dashboard) |
+| `g c` | Checklisten |
+| `g b` | Bauzeitenplan |
+| `g a` | Aufgaben |
+| `g m` | Mängel |
+| `g k` | Kontakte |
+
+## Aktionen
+
+| Taste | Aktion |
+|---|---|
+| `n` | Neuer Mangel anlegen |
+
+## Sheet-Bedienung
+
+| Geste | Aktion |
+|---|---|
+| Wischen nach unten am Handle (>100px) | Sheet schließen |
+| Tap auf Scrim | Sheet schließen |
+| `Esc` | Sheet schließen |
+
+## Plan-Viewer
+
+| Geste | Aktion |
+|---|---|
+| Tap auf Plan | Mangel-Sheet öffnen, Position prefilled |
+| Tap auf Pin | Inline-Vorschau (Foto, Status, Quick-Actions) |
+| Drag-Pin | Pin auf Plan verschieben |
+| Pin-Inline → "···" | Status ändern (Bestätigt / Erledigt / etc.) |
+
+## Foto-Annotation
+
+In der Mangel-Detail-Ansicht: ✎-Button auf Foto-Tile öffnet Annotator.
+
+| Werkzeug | Was es tut |
+|---|---|
+| ◯ | Roter Kreis |
+| ↗ | Roter Pfeil |
+| ✎ | Freihand-Stift |
+| ✖ | Stempel ("Mängel hier!", "Siehe Foto", "Nachbessern", "Abnahme verweigert") |
+
+`↶ Zurück` rückgängig, `Alle löschen` Reset, `Speichern` legt das annotierte Bild als zusätzliches Foto neben dem Original an.

--- a/docs/UX_AUDIT.md
+++ b/docs/UX_AUDIT.md
@@ -255,3 +255,90 @@ Nach Hebelwirkung (visual impact pro Code-Aufwand):
 14. **Empty-State-Illustrations** (Brand-Polish, last)
 
 Realistic time-box: ~3h. Falls eng: 6, 9, 11, 14 vereinfachen oder verschieben.
+
+---
+
+## Loop 3 — Self-Critique nach Implementation
+
+> "Würde Tim Cook das auf der WWDC zeigen?" — die ehrliche Antwort und was es noch braucht.
+
+### Was sitzt gut
+
+**Topbar-Glass + Tabbar-Pill**: das fühlt sich wirklich wie iOS-Settings an. Der
+backdrop-blur(20px) macht den Unterschied. Active-Tab mit red-soft Pill ist
+charakteristisch genug, um auf einen Blick erkannt zu werden, ohne aufdringlich
+zu sein.
+
+**Plan-Viewer Pin-Workflow**: zwischen Tap-für-Preview, Drag-zum-Verschieben,
+Quick-Status-Menu im Inline-Card und Per-Gewerk-Filter haben wir die DocMa MM
+Feature-Parität auf dem Plan deutlich überholt. Der Halo (gewerk-color als
+Background, Status-Border als Halo) ist subtil, lesbar, und visuell klar.
+
+**Photo-Annotator**: sehr nahe an DocMa MM. Stempel-Bibliothek, Undo,
+4 Werkzeuge, sauberes Speicher-Verhalten (Original bleibt). Was noch nicht passt:
+keine Text-Stamp mit Custom-Eingabe (nur die 4 Voreinstellungen). Phase 5+ falls
+Bedarf.
+
+**Cmd+K**: chord-Navigation `g+d` etc. ist genau der Power-User-Move, den
+ein Bauleiter mit ein paar Tagen Routine schätzt. Suchfeld ist responsive,
+Filter ist instant.
+
+**Sheet drag-to-close**: die Pointer-Drag-Geste mit Spring-Snap ist pure iOS.
+
+### Was noch nicht gut sitzt
+
+1. **Skeleton-Screens fehlen**. Bei Initial-Load sehen alle Listen kurz „leer"
+   aus. Auf 3G wäre das spürbar. Status: aufgeschoben (Performance-relevant aber
+   nicht visual breakage).
+
+2. **Pull-to-Refresh fehlt**. Mobile-Native-Feel-Lücke. Aufgeschoben — Realtime
+   sync (Phase 1.7) deckt 80% der use-cases ab; manuelle Refresh ist halt
+   Browser-Reload.
+
+3. **Empty-State-Illustrationen** sind weiterhin "·"-Punkt. Brand-Polish-Lücke.
+   Aufgeschoben: SVG-Illustrations brauchen Designer-Input.
+
+4. **Dashboard Hero-Ring** zeigt 0% statisch. Sollte animiert auf Mount aufladen.
+   Quick-Fix: SVG `stroke-dashoffset` mit transition. → in Loop 3 nachgereicht.
+
+5. **Aktivität-Feed** hat Avatar-Bubbles als "Initialen-Kreis" noch nicht.
+   Aufgeschoben — braucht Profile-Color-Mapping.
+
+6. **Bauzeit Bar-Hover-Tooltip** mit Datum/Dauer fehlt. → in Loop 3 nachgereicht.
+
+7. **Mängel Multi-Select + Bulk-Actions** fehlt. Sticky-Group-Header sind drin,
+   aber Long-Press → Multi-Select ist Phase 5. (Volume zu klein für ROI im RC2.)
+
+8. **Swipe-Actions auf Mängel-Cards** (mobile): Phase 5. CapacitorJS oder reine
+   Touch-Gesten sind für ein 3-Tage-Build over-engineered.
+
+9. **Toast** ist jetzt Glas, aber Stack-Behavior fehlt (mehrere Toasts
+   überschreiben sich). Akzeptabel.
+
+### Was direkt nachgereicht wird
+
+- Hero-Progress-Ring animiert
+- Bauzeit-Bar Hover-Tooltip
+- Aktivität-Feed Avatar-Bubbles aus Initialen + deterministischer Color
+- Skeleton-Component für Listen (universell, billig)
+
+### Bewusst aufgeschoben (Phase 5+)
+
+- Text-Stamp mit Custom-Text in Annotator
+- Pull-to-Refresh
+- Multi-Select + Bulk-Actions auf Mängel-Liste
+- Swipe-Actions auf Mobile
+- Empty-State-SVGs
+- Dark-Mode
+- Bar-Drag Snap-Linien zwischen Tagen
+
+### Verdict
+
+**Würde Tim Cook das zeigen?** Nicht das ganze Produkt — Cron-Calendar wirkt
+auf jeder Pixelreihe noch polierter. Aber die **Plan-Viewer-Page**, der
+**Photo-Annotator** und das **Cmd+K-Erlebnis** haben "Hero-Demo"-Qualität.
+Der Rest ist iOS-Settings-solide.
+
+Für eine Branche, in der DocMa MM heute der Wettbewerber ist — und das ist eine
+Native-App von 2018 mit Native-Tooling — sind wir mit einer 3-Tage-Web-PWA auf
+sehr respektablem Niveau.

--- a/docs/UX_AUDIT.md
+++ b/docs/UX_AUDIT.md
@@ -1,0 +1,257 @@
+# UX-Audit & Refinement-Strategie
+
+Ziel: von "funktional" zu "premium". Vorbild: iOS 17 Settings, Linear, Things 3, Cron-Calendar, DocMa MM.
+
+---
+
+## 0. UX-Vokabular (Tokens für die ganze App)
+
+### Spacing-Skala (4-Multiples)
+`4 / 8 / 12 / 16 / 20 / 24 / 32 / 40 / 56 / 72`. Keine ad-hoc-Werte mehr.
+
+### Typo-Skala (SF-Pro-style)
+- `caption-xs` 11 / -0.005em / mono — IDs, Datum, technical labels
+- `caption-sm` 13 / -0.005em — secondary text
+- `body` 15 / 0 — paragraph
+- `body-lg` 17 / 0 — list-item titles
+- `title-3` 22 / -0.015em — section-titles, card-heroes
+- `title-2` 28 / -0.02em — page-titles
+- `title-1` 34 / -0.025em — hero-titles
+- `display` 41 / -0.03em — first-screen ("Bauleiter-Cockpit")
+- `numeric` 56 / -0.04em — big metrics
+- `numeric-xl` 72 / -0.05em — splash
+
+### Easing
+- `ease-out-expo` `cubic-bezier(0.16, 1, 0.3, 1)` — open animations
+- `ease-out-quint` `cubic-bezier(0.22, 1, 0.36, 1)` — exit animations
+- `ease-spring` `cubic-bezier(0.34, 1.56, 0.64, 1)` — bouncy emphasis
+- Durations: `120ms` micro, `220ms` standard, `400ms` page-transitions
+
+### Blur / Glass
+- `bg-glass` `rgba(255,255,255,0.72) backdrop-filter: saturate(180%) blur(20px)`
+- `bg-glass-dark` `rgba(15,15,16,0.72) backdrop-filter: saturate(180%) blur(20px)`
+- `bg-glass-frost` `rgba(255,255,255,0.55) backdrop-filter: blur(28px)` — sheets
+
+### Depth-Layer
+- L0: `bg` (`#F6F4F1`) — page
+- L1: `paper` (`#FFFFFF`) — card on page
+- L2: `paper-tint` (`#FAF8F4`) — section inside card / hover
+- L3: `paper-deep` (gradient overlay 4% black) — input wells, callouts
+- Borders: `--line` 8% black, `--line-strong` 16% black, `--line-active` 100% red
+
+### Reduced-Motion
+Alle Spring-Animationen über `@media (prefers-reduced-motion: reduce)` auf
+`200ms ease-out` reduzieren. Kein Bouncing.
+
+---
+
+## 1. Per-Page Audit
+
+### Dashboard (`/[projectId]/dashboard`)
+
+**Schwächen**
+- Hero ist OK, aber die Progress-Ring hat einen statisch "0%"-Label. Wirkt tot.
+- Quick-Cards sind generic, zu kompakt — Linear nutzt 80px+ height mit subtiler Beschreibung.
+- Activity-Feed ohne Avatar; nur "Jonas hat …" Text. iOS Messages-Look fehlt.
+
+**Verbesserungen**
+- Animierte Progress-Ring mit Counter-Animation auf Mount.
+- Quick-Cards größer, mit "n offen" Stat-Inline und Hover-Lift (translateY -3px + shadow-up).
+- Activity-Feed: Avatar-Bubble (Initialen mit Gewerk-Color), Time-Ago animiert geupdated.
+
+### Checklisten-Liste (`/checklisten`)
+
+**Schwächen**
+- Cards sind solide aber statisch. Kein Hover-Polish.
+- Keine Sektion-Headers (z.B. "Ausstehend" / "In Arbeit" / "Erledigt"-Gruppierung).
+- Filter-Chips ohne Animation beim Wechseln.
+
+**Verbesserungen**
+- Cards mit Hover-Glow (Shadow expand statt nur lift).
+- Smart-Sort: "Heute aktiv" oben, dann "Pending", dann "Done" zusammengeklappt.
+- Filter-Chips mit Layout-Shift-Animation wenn count sich ändert.
+
+### Checklisten-Detail (`/checklisten/[id]`)
+
+**Schwächen**
+- Pills sehen nicht "tappbar" aus auf den ersten Blick.
+- Viel vertikaler Scroll bei vielen Items + Häusern — kein Anker.
+- Sheet schlie&szlig;t per Klick auf Scrim, aber Drag-down zum Schlie&szlig;en fehlt.
+
+**Verbesserungen**
+- Pills mit subtiler shadow und stärkerem Active-Press-Feedback.
+- Floating-Section-Indicator (sticky pill an der Seite) zeigt "Sektion 3/9".
+- Sheet drag-to-close mit Spring-Snap.
+
+### Bauzeitenplan (`/bauzeitenplan`)
+
+**Schwächen**
+- Today-Line ist statisch.
+- Bar-Hover ist plain, kein Tooltip mit Datum/Dauer.
+- Drag-Preview: harter Sprung beim Loslassen.
+- Wochenenden subtil aber nicht erkennbar als "anders".
+
+**Verbesserungen**
+- Pulsierender Dot auf Today-Line.
+- Bar-Hover: Tooltip mit Start/Ende/Dauer/Gewerk fades in.
+- Drag mit Snap-to-Day-Linien (semi-transparente vertikale Linien).
+- Wochenenden mit diagonal-Hatch-Pattern (subtle, max 4% black).
+- Critical-Path-Toggle: smooth color-transition (alle Bars 300ms).
+
+### Aufgaben (`/aufgaben`)
+
+**Schwächen**
+- Cards alle gleich aussehend; keine visuelle Hierarchie nach Priorität.
+- "Überfällig"-Group hat roten Header aber Cards selbst nicht visualisert.
+- Kein Empty-State pro Group.
+
+**Verbesserungen**
+- Überfällige Cards: zusätzlicher roter linker Border (3px) + sehr subtiler red-soft tint.
+- Priorität-1 Cards: dezent fett gedruckter Titel.
+- Empty pro Group: "✓ Nichts überfällig.", "Noch frei diese Woche."
+- Gruppen-Headers: count-Badge animiert beim Filter-Wechsel.
+
+### Mängel-Liste (`/maengel`)
+
+**Schwächen**
+- Liste ist linear, keine sticky-Header pro Status.
+- Status-Pill und Mangel-Color-Stripe sind gut, aber kein Foto-Thumbnail.
+- Bulk-Aktionen fehlen (Multi-Select).
+
+**Verbesserungen**
+- Sticky-Group-Headers ("OFFEN · 12", "GESENDET · 4", "ERLEDIGT · 8").
+- Erstes Foto als Thumbnail links neben Color-Stripe (40×40px).
+- Long-Press → Multi-Select-Mode mit Bulk-Bar unten (Status, Versenden, Archivieren).
+- Swipe-Actions auf Mobile (links: schnell-Status; rechts: archivieren).
+
+### Mängel-Detail (`/maengel/[id]`)
+
+**Schwächen**
+- Status-Action-Buttons sind plain `btn-ghost` — wirken nicht wie Decision-Action.
+- Foto-Tiles sind quadratisch-statisch.
+- History-Feed mit `clock`-Icon für alles — eintönig.
+
+**Verbesserungen**
+- Status-Buttons: jeweils mit subtler Status-Farbe als Pill statt Ghost-Button.
+- Foto-Tiles: Tap → Lightbox-Zoom (smooth scale-fade).
+- History: Icon variiert (created, status_changed, photo_added, sent).
+- "Annotation"-Button auf Foto-Tile → Edit-Mode.
+
+### Plan-Viewer (`/maengel/plaene/[id]`)
+
+**Schwächen**
+- Pins zeigen nur shortId — kein Status farbig, kein Cluster bei Zoom-out.
+- Klick auf Pin: keine Inline-Vorschau, springt sofort weg.
+- Kein Filter ("nur Maler-Mängel").
+
+**Verbesserungen**
+- Pins farbig nach Status: open=red, sent=amber, resolved=green.
+- Tap-Pin: Floating-Card mit Foto-Vorschau + Title + Status; Tap erneut → navigate.
+- Long-Press-Pin: Quick-Actions-Menu (Status ändern, Foto, Löschen).
+- Filter-Layer-Bar oben: Toggle pro Gewerk; deaktivierte Pins fade-out.
+- Cluster-Bubbles bei Zoom-out (10+ Pins in 50px-Radius werden "12").
+
+### Settings / Kontakte (`/kontakte`)
+
+**Schwächen**
+- Liste ohne Gruppierung nach Gewerk.
+- Kein Foto/Avatar pro Kontakt.
+- Search trennt nicht zwischen "Match in Firma" und "Match in Email".
+
+**Verbesserungen**
+- Gruppierung nach Gewerk mit sticky-Header.
+- Initialen-Avatar (Firmen-Initiale) als bunter Kreis (Gewerk-Color).
+- Search-Match-Highlighting (gelbe Markierung).
+
+### Empty-States generell
+
+**Schwäche**
+- Aktuell: "·"-Emoji + grauer Text. Trist.
+
+**Verbesserung**
+- Custom-SVG-Illustration pro Page (Hofmann-Style, rote Akzente, line-art).
+- Kontextueller CTA ("Mangel hier anlegen", "Plan hochladen").
+
+---
+
+## 2. Globale Verbesserungen
+
+### Topbar
+- Glass-Effect: `bg-glass-dark` (translucent ink + 20px blur)
+- Project-Name mit smooth-shrink wenn gescrollt (32px → 14px font-size)
+- Tab-Indicator-Bar (3px rote Linie unter aktivem Tab) animiert sliden zwischen Tabs
+
+### Tabbar (Mobile)
+- Glass-Effect statt opaque white
+- Active-Tab: Indicator-Pill (rounded rect mit red-soft Hintergrund)
+- Tap-Feedback: Scale-Down 0.92 + leichter Vibrate (`navigator.vibrate(8)`)
+
+### Sheets (Bottom-Sheets)
+- Frosted Top (Handle-Bar-Region: bg-glass-frost statt opaque)
+- Drag-to-Close: Touch-Drag nach unten > 100px → close (Spring zurück sonst)
+- Open-Animation: spring statt cubic-bezier (custom JS oder Svelte transition mit elastic)
+
+### Toasts
+- Glass-Background, kein Solid
+- Slide-Up + Fade-In (220ms ease-out-expo)
+- Nicht 2200ms Timeout sondern: 1500ms für Success, 3500ms für Errors
+
+### Cards
+- Hover: `transform: translateY(-2px); box-shadow: shadow-2`
+- Active/Press: `transform: scale(0.98)`
+- Border: zero by default, appears on hover (subtle)
+
+### Buttons
+- Press-State: Scale 0.97 + leichtes inner-shadow
+- Disabled: opacity 0.4 + cursor not-allowed
+- Loading: Spinner inline statt Text-Replacement
+
+### Form Inputs
+- Floating-Label-Style optional (Material 3-vibe)
+- Focus: red-border + subtle red-glow (box-shadow)
+- Validation-State: border + helper-text farbig
+
+### Photos
+- Tap-Animation: Scale-Down zu 0.96 (50ms) → Scale-Up zu 1.0 (220ms ease-spring)
+- Lightbox: Backdrop fade + image scale from origin to fit
+
+### Skeleton-Screens
+- Statt Spinner bei Initial-Load: graue Placeholder-Cards mit Pulse-Animation
+- Aufgaben, Mängel, Checklisten Listen, Plan-Viewer
+
+### Pull-to-Refresh (Mobile)
+- Touch-Drag-Down auf Top der Liste
+- Threshold ~80px → Refresh (invalidateAll)
+- Visual: drehender Indicator (rote Linie krümmt sich zum Kreis)
+
+---
+
+## 3. Was wir BEWUSST nicht machen
+
+- Keine 3D-Tilt-Effekte auf Hover (lenkt ab, eats CPU).
+- Keine globale Confetti-Animation bei Erfolg (würde eine Baustelle nicht ernst nehmen).
+- Keine Dark-Mode-Variante in v1.0 — Hofmann-Brand ist auf hellem BG, dark erfordert komplette Token-Erweiterung. Phase 5+.
+- Keine Voice-Commands für Nav (nur Voice-to-Text in Defect-Description).
+
+---
+
+## 4. Reihenfolge der Implementierung (Loop 2)
+
+Nach Hebelwirkung (visual impact pro Code-Aufwand):
+
+1. **Tokens-Refactor** — neue Skala in app.css + tailwind.config (keine Component-Änderung, aber Foundation)
+2. **Topbar Glass + Tab-Indicator** (allgegenwärtig, sofort sichtbar)
+3. **Sheet Frosted-Top + Drag-to-Close** (auf allen Detail-Pages aktiv)
+4. **Spring-Animationen** (universelle Util `lib/motion.ts`)
+5. **Card-Hover-Polish + Press-States** (alle Listen profitieren)
+6. **Pin-Workflow Plan-Viewer** (Killer-Feature für Mängel)
+7. **Photo-Annotation in Mangel-Detail** (DocMa-Killer)
+8. **Bulk-Actions + Multi-Select Mängel** (Pro-User-Feature)
+9. **Bauzeit-Polish** (Tooltip, Snap, Hatch-Pattern)
+10. **Skeleton-Screens** (Perceived-Performance)
+11. **Pull-to-Refresh** (Mobile-Native-Feel)
+12. **Keyboard-Shortcuts + Command-Palette** (Power-User)
+13. **Toast-Glass** (Detail-Polish)
+14. **Empty-State-Illustrations** (Brand-Polish, last)
+
+Realistic time-box: ~3h. Falls eng: 6, 9, 11, 14 vereinfachen oder verschieben.

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -23,12 +23,14 @@ import {
   checklistSections,
   checklistItems,
   gewerkChecklistTemplates,
-  contacts
+  contacts,
+  textbausteine
 } from '../src/lib/db/schema';
 import { GEWERKE_SEED } from '../src/lib/seed/gewerke';
 import { CHECKLISTS } from '../src/lib/seed/checklists';
 import { GEWERK_CHECKLIST_TEMPLATES } from '../src/lib/seed/gewerk-checklists';
 import { CONTACTS_DUMMY } from '../src/lib/seed/contacts';
+import { TEXTBAUSTEINE_SEED } from '../src/lib/seed/textbausteine';
 
 const url = process.env.DATABASE_URL;
 if (!url) {
@@ -142,9 +144,28 @@ async function seedGlobalContacts() {
   }
 }
 
+async function seedTextbausteine() {
+  console.log('[seed] textbausteine …');
+  await db.execute(sql`DELETE FROM textbausteine`);
+  const allGewerke = await db.select().from(gewerke);
+  const byName = new Map(allGewerke.map((g) => [g.name, g.id]));
+  for (let i = 0; i < TEXTBAUSTEINE_SEED.length; i++) {
+    const t = TEXTBAUSTEINE_SEED[i];
+    const gid = byName.get(t.gewerk);
+    if (!gid) continue;
+    await db.insert(textbausteine).values({
+      gewerkId: gid,
+      label: t.label,
+      body: t.body,
+      sortOrder: i
+    });
+  }
+}
+
 await seedGewerke();
 await seedChecklists();
 await seedGewerkChecklistTemplates();
+await seedTextbausteine();
 await seedGlobalContacts();
 console.log('[seed] done.');
 await client.end();

--- a/src/app.css
+++ b/src/app.css
@@ -33,6 +33,79 @@
   --display: 'Archivo', system-ui, sans-serif;
   --body: 'Inter', system-ui, sans-serif;
   --mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  /* ---------- Premium UX system (Phase B) ---------- */
+  /* Easing curves (Apple-ish) */
+  --ease-out-expo:  cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-spring:    cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  /* Durations */
+  --d-micro: 120ms;
+  --d-fast:  180ms;
+  --d-std:   220ms;
+  --d-page:  400ms;
+
+  /* Glass surfaces */
+  --glass-light:  rgba(255, 255, 255, 0.72);
+  --glass-frost:  rgba(255, 255, 255, 0.55);
+  --glass-dark:   rgba(15, 15, 16, 0.72);
+  --blur-std:     saturate(180%) blur(20px);
+  --blur-strong:  saturate(180%) blur(28px);
+
+  /* Depth layers (use on bg) */
+  --layer-0: var(--bg);          /* page */
+  --layer-1: var(--paper);       /* card */
+  --layer-2: var(--paper-tint);  /* card-section */
+  --layer-3: rgba(15, 15, 16, 0.04); /* input wells */
+
+  /* Status accent tints (subtle) */
+  --tint-red:   rgba(227, 6, 19, 0.06);
+  --tint-amber: rgba(201, 119, 0, 0.06);
+  --tint-green: rgba(46, 125, 50, 0.06);
+
+  /* Press scale (apply via transition) */
+  --press-scale: 0.975;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --ease-spring:    var(--ease-out-quint);
+    --d-micro: 80ms;
+    --d-fast:  120ms;
+    --d-std:   140ms;
+    --d-page:  200ms;
+  }
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: var(--d-fast) !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Universal interaction polish */
+@layer base {
+  button, a, [role="button"] {
+    transition: transform var(--d-micro) var(--ease-spring),
+                background-color var(--d-fast) var(--ease-out-expo),
+                box-shadow var(--d-fast) var(--ease-out-expo),
+                border-color var(--d-fast) var(--ease-out-expo),
+                color var(--d-fast) var(--ease-out-expo);
+  }
+  button:active, a:active, [role="button"]:active {
+    transform: scale(var(--press-scale));
+  }
+  button:disabled, a:disabled {
+    transform: none !important;
+    cursor: not-allowed !important;
+    opacity: 0.45;
+  }
+  :focus-visible {
+    outline: 2px solid var(--red);
+    outline-offset: 2px;
+    border-radius: 6px;
+  }
 }
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -57,13 +130,18 @@ input:focus, textarea:focus, select:focus { outline: 2px solid var(--red); outli
 main { flex: 1; padding-bottom: 80px; }
 .page { padding: 14px; max-width: 1100px; margin: 0 auto; }
 
-/* Topbar */
+/* Topbar (glass) */
 .topbar {
   position: sticky; top: 0; z-index: 50;
-  background: var(--ink); color: #fff;
+  background: var(--glass-dark); color: #fff;
+  -webkit-backdrop-filter: var(--blur-std);
+  backdrop-filter: var(--blur-std);
   padding: 10px 14px;
   display: flex; align-items: center; gap: 12px;
   border-bottom: 1px solid rgba(255, 255, 255, .08);
+}
+@supports not (backdrop-filter: blur(1px)) {
+  .topbar { background: var(--ink); }
 }
 .topbar-logo {
   width: 30px; height: 30px;
@@ -107,10 +185,12 @@ main { flex: 1; padding-bottom: 80px; }
 .icon-btn:active { transform: scale(.96); }
 .icon-btn svg { width: 18px; height: 18px; }
 
-/* Tabbar */
+/* Tabbar (glass) */
 .tabbar {
   position: sticky; bottom: 0; z-index: 40;
-  background: var(--paper);
+  background: var(--glass-light);
+  -webkit-backdrop-filter: var(--blur-std);
+  backdrop-filter: var(--blur-std);
   border-top: 1px solid var(--line);
   display: flex; gap: 0;
   overflow-x: auto;
@@ -118,6 +198,9 @@ main { flex: 1; padding-bottom: 80px; }
   box-shadow: 0 -4px 16px rgba(15, 15, 16, .04);
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
+}
+@supports not (backdrop-filter: blur(1px)) {
+  .tabbar { background: var(--paper); }
 }
 .tabbar::-webkit-scrollbar { display: none; }
 @media (min-width: 640px) {
@@ -128,15 +211,22 @@ main { flex: 1; padding-bottom: 80px; }
   min-width: 64px;
   padding: 8px 4px;
   display: flex; flex-direction: column; align-items: center; gap: 4px;
-  color: var(--muted); border-radius: 8px; transition: all .15s;
+  color: var(--muted); border-radius: 10px;
   text-decoration: none;
+  position: relative;
 }
-.tabbar-btn svg { width: 20px; height: 20px; }
+.tabbar-btn svg {
+  width: 20px; height: 20px;
+  transition: transform var(--d-fast) var(--ease-spring);
+}
 .tabbar-btn span {
   font-size: 10px; font-weight: 600;
   font-family: var(--mono); letter-spacing: .02em; text-transform: uppercase;
 }
+.tabbar-btn.active { background: var(--red-soft); }
+.tabbar-btn.active svg { transform: translateY(-1px); }
 .tabbar-btn.active, .tabbar-btn.active span { color: var(--red); }
+.tabbar-btn:active svg { transform: scale(0.85); }
 
 /* Buttons */
 .btn {
@@ -233,11 +323,17 @@ main { flex: 1; padding-bottom: 80px; }
   color: var(--muted);
   text-transform: uppercase; letter-spacing: .04em;
   white-space: nowrap;
-  transition: all .12s;
   cursor: pointer;
 }
-.filter-pill:hover { border-color: var(--ink); color: var(--ink); }
-.filter-pill.active { background: var(--ink); color: #fff; border-color: var(--ink); }
+.filter-pill:hover {
+  border-color: var(--ink); color: var(--ink);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-1);
+}
+.filter-pill.active {
+  background: var(--ink); color: #fff; border-color: var(--ink);
+  box-shadow: 0 4px 12px rgba(15, 15, 16, 0.15);
+}
 .filter-pill .badge {
   display: inline-block; margin-left: 6px;
   padding: 1px 6px; background: rgba(255, 255, 255, .18); border-radius: 8px;
@@ -335,11 +431,15 @@ main { flex: 1; padding-bottom: 80px; }
 .stepper-btn:disabled { opacity: .3; cursor: not-allowed; }
 .stepper-value { min-width: 50px; text-align: center; font-family: var(--display); font-weight: 800; font-size: 20px; line-height: 1; }
 
-/* Sheet */
+/* Sheet (glass top) */
 .scrim {
   position: fixed; inset: 0; z-index: 100;
-  background: rgba(15, 15, 16, .55); backdrop-filter: blur(2px);
-  opacity: 0; pointer-events: none; transition: opacity .25s;
+  background: rgba(15, 15, 16, .42);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  opacity: 0; pointer-events: none;
+  transition: opacity var(--d-std) var(--ease-out-expo);
+  border: none; padding: 0; cursor: pointer;
 }
 .scrim.open { opacity: 1; pointer-events: auto; }
 .sheet {
@@ -347,12 +447,29 @@ main { flex: 1; padding-bottom: 80px; }
   background: var(--paper);
   border-top-left-radius: 22px; border-top-right-radius: 22px;
   box-shadow: var(--shadow-3);
-  transform: translateY(100%); transition: transform .3s cubic-bezier(.2, .8, .2, 1);
+  transform: translateY(100%);
+  transition: transform var(--d-page) var(--ease-out-expo);
   max-height: 92dvh;
   display: flex; flex-direction: column;
+  touch-action: pan-y;
 }
 .sheet.open { transform: translateY(0); }
-.sheet-handle { width: 40px; height: 4px; background: var(--line-strong); border-radius: 2px; margin: 10px auto 0; flex-shrink: 0; }
+.sheet.dragging { transition: none; }
+.sheet-handle-area {
+  flex-shrink: 0;
+  background: var(--glass-frost);
+  -webkit-backdrop-filter: var(--blur-strong);
+  backdrop-filter: var(--blur-strong);
+  border-top-left-radius: 22px; border-top-right-radius: 22px;
+  padding-top: 4px;
+  cursor: grab;
+}
+.sheet-handle-area:active { cursor: grabbing; }
+.sheet-handle {
+  width: 40px; height: 4px;
+  background: var(--line-strong); border-radius: 2px;
+  margin: 10px auto 0;
+}
 .sheet-head { padding: 12px 18px 6px; display: flex; align-items: flex-start; gap: 12px; flex-shrink: 0; }
 .sheet-head-text { flex: 1; min-width: 0; }
 .sheet-eyebrow {
@@ -375,18 +492,23 @@ main { flex: 1; padding-bottom: 80px; }
   background: var(--paper); flex-shrink: 0;
 }
 
-/* Toast */
+/* Toast (glass) */
 .toast {
   position: fixed; left: 50%; bottom: 90px;
-  transform: translateX(-50%) translateY(20px);
-  background: var(--ink); color: #fff;
+  transform: translateX(-50%) translateY(20px) scale(0.9);
+  background: var(--glass-dark);
+  -webkit-backdrop-filter: var(--blur-std);
+  backdrop-filter: var(--blur-std);
+  color: #fff;
   padding: 10px 18px; border-radius: 999px;
   font-size: 13px; font-weight: 500;
-  z-index: 300; opacity: 0; transition: all .25s;
+  z-index: 300; opacity: 0;
+  transition: all var(--d-std) var(--ease-out-expo);
   box-shadow: var(--shadow-2); pointer-events: none;
   max-width: calc(100vw - 32px);
 }
-.toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+.toast.show { opacity: 1; transform: translateX(-50%) translateY(0) scale(1); }
+@supports not (backdrop-filter: blur(1px)) { .toast { background: var(--ink); } }
 
 /* Empty state */
 .empty { text-align: center; padding: 36px 18px; color: var(--muted); }

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+  /** Cmd+K / Ctrl+K command-palette + global keyboard shortcuts. */
+  import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+  import Icon, { type IconName } from './Icon.svelte';
+  import { page } from '$app/state';
+  import { fly } from 'svelte/transition';
+  import { ease } from '$lib/motion';
+
+  let open = $state(false);
+  let query = $state('');
+  let activeIdx = $state(0);
+  let inputEl: HTMLInputElement | null = $state(null);
+
+  type Cmd = {
+    id: string;
+    label: string;
+    shortcut?: string;
+    icon: IconName;
+    action: () => void;
+    section?: string;
+  };
+
+  function projectId(): string | null {
+    const m = page.url.pathname.match(/^\/([0-9a-f-]{36})/);
+    return m ? m[1] : null;
+  }
+
+  let commands = $derived.by<Cmd[]>(() => {
+    const pid = projectId();
+    const out: Cmd[] = [];
+    if (pid) {
+      out.push(
+        { id: 'nav-dashboard', label: 'Übersicht', icon: 'home', shortcut: 'g d', action: () => goto(`/${pid}/dashboard`), section: 'Navigation' },
+        { id: 'nav-checklisten', label: 'Checklisten', icon: 'list', shortcut: 'g c', action: () => goto(`/${pid}/checklisten`), section: 'Navigation' },
+        { id: 'nav-bauzeit', label: 'Bauzeitenplan', icon: 'gantt', shortcut: 'g b', action: () => goto(`/${pid}/bauzeitenplan`), section: 'Navigation' },
+        { id: 'nav-aufgaben', label: 'Aufgaben', icon: 'tasks', shortcut: 'g a', action: () => goto(`/${pid}/aufgaben`), section: 'Navigation' },
+        { id: 'nav-maengel', label: 'Mängel', icon: 'defect', shortcut: 'g m', action: () => goto(`/${pid}/maengel`), section: 'Navigation' },
+        { id: 'nav-plaene', label: 'Pläne', icon: 'file', action: () => goto(`/${pid}/maengel/plaene`), section: 'Navigation' },
+        { id: 'nav-kontakte', label: 'Kontakte', icon: 'phone', shortcut: 'g k', action: () => goto(`/${pid}/kontakte`), section: 'Navigation' },
+        { id: 'nav-musterdetails', label: 'Musterdetails', icon: 'apartment', action: () => goto(`/${pid}/musterdetails`), section: 'Navigation' },
+        { id: 'nav-gewerk-checks', label: 'Gewerk-Checklisten', icon: 'check', action: () => goto(`/${pid}/gewerk-checklisten`), section: 'Navigation' },
+        { id: 'nav-aktivitaet', label: 'Aktivität', icon: 'activity', action: () => goto(`/${pid}/aktivitaet`), section: 'Navigation' },
+        { id: 'create-mangel', label: 'Neuer Mangel', icon: 'plus', shortcut: 'n', action: () => goto(`/${pid}/maengel?new=1`), section: 'Aktionen' }
+      );
+    }
+    out.push(
+      { id: 'nav-projects', label: 'Projekt wechseln', icon: 'building', action: () => goto(`/projects`), section: 'Allgemein' },
+      { id: 'shortcuts-help', label: 'Tastenkürzel anzeigen', icon: 'gear', shortcut: '?', action: () => goto(`/shortcuts`), section: 'Allgemein' }
+    );
+    return out;
+  });
+
+  let filtered = $derived.by<Cmd[]>(() => {
+    if (!query.trim()) return commands;
+    const q = query.toLowerCase();
+    return commands.filter((c) => c.label.toLowerCase().includes(q));
+  });
+
+  function handleSelect(idx: number) {
+    const c = filtered[idx];
+    if (!c) return;
+    open = false;
+    query = '';
+    setTimeout(() => c.action(), 30);
+  }
+
+  let chord = '';
+  let chordTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearChord() {
+    chord = '';
+    if (chordTimer) clearTimeout(chordTimer);
+  }
+
+  function handleGlobalKey(e: KeyboardEvent) {
+    const target = e.target as HTMLElement | null;
+    const inField = target?.matches('input, textarea, [contenteditable="true"]');
+
+    // Cmd+K / Ctrl+K
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      open = !open;
+      query = '';
+      activeIdx = 0;
+      setTimeout(() => inputEl?.focus(), 50);
+      return;
+    }
+
+    if (open) {
+      if (e.key === 'Escape') { open = false; return; }
+      if (e.key === 'ArrowDown') { e.preventDefault(); activeIdx = Math.min(filtered.length - 1, activeIdx + 1); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); activeIdx = Math.max(0, activeIdx - 1); return; }
+      if (e.key === 'Enter') { e.preventDefault(); handleSelect(activeIdx); return; }
+    }
+
+    if (inField) return;
+
+    // Single-key shortcuts
+    if (e.key === '/' || e.key === '?') {
+      e.preventDefault();
+      open = true;
+      setTimeout(() => inputEl?.focus(), 50);
+      return;
+    }
+
+    if (e.key === 'n') {
+      e.preventDefault();
+      const pid = projectId();
+      if (pid) goto(`/${pid}/maengel?new=1`);
+      return;
+    }
+
+    // Chord 'g <x>'
+    if (chord === 'g') {
+      const pid = projectId();
+      if (!pid) { clearChord(); return; }
+      const map: Record<string, string> = { d: 'dashboard', c: 'checklisten', b: 'bauzeitenplan', a: 'aufgaben', m: 'maengel', k: 'kontakte' };
+      const dest = map[e.key];
+      if (dest) {
+        e.preventDefault();
+        goto(`/${pid}/${dest}`);
+      }
+      clearChord();
+      return;
+    }
+    if (e.key === 'g') {
+      chord = 'g';
+      chordTimer = setTimeout(clearChord, 1200);
+      return;
+    }
+  }
+
+  onMount(() => {
+    window.addEventListener('keydown', handleGlobalKey);
+    return () => window.removeEventListener('keydown', handleGlobalKey);
+  });
+
+  // Reset active index when filter changes
+  $effect(() => {
+    void filtered;
+    activeIdx = 0;
+  });
+</script>
+
+{#if open}
+  <button class="cmdk-scrim" onclick={() => (open = false)} aria-label="Schließen"></button>
+  <div class="cmdk-panel" role="dialog" aria-label="Befehlspalette" in:fly|local={{ y: -8, duration: 180, easing: ease.outExpo }}>
+    <div class="cmdk-input-wrap">
+      <Icon name="list" size={14} />
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        class="cmdk-input"
+        placeholder="Was möchtest du tun?"
+        autocomplete="off"
+        spellcheck="false"
+      />
+      <span class="cmdk-hint">ESC</span>
+    </div>
+    <ul class="cmdk-list" role="listbox">
+      {#each filtered as c, i (c.id)}
+        <li>
+          <button
+            class="cmdk-item"
+            class:active={i === activeIdx}
+            onclick={() => handleSelect(i)}
+            onmouseenter={() => (activeIdx = i)}
+          >
+            <Icon name={c.icon} size={14} />
+            <span class="cmdk-label">{c.label}</span>
+            {#if c.section}<span class="cmdk-section">{c.section}</span>{/if}
+            {#if c.shortcut}<span class="cmdk-shortcut">{c.shortcut}</span>{/if}
+          </button>
+        </li>
+      {/each}
+      {#if filtered.length === 0}
+        <li class="cmdk-empty">Keine Treffer.</li>
+      {/if}
+    </ul>
+  </div>
+{/if}
+
+<style>
+  .cmdk-scrim {
+    position: fixed; inset: 0; z-index: 400;
+    background: rgba(15, 15, 16, 0.42);
+    -webkit-backdrop-filter: blur(4px);
+    backdrop-filter: blur(4px);
+    border: none; cursor: pointer;
+  }
+  .cmdk-panel {
+    position: fixed; top: 12vh; left: 50%; transform: translateX(-50%);
+    width: min(560px, calc(100vw - 32px));
+    background: var(--glass-frost);
+    -webkit-backdrop-filter: var(--blur-strong);
+    backdrop-filter: var(--blur-strong);
+    border: 1px solid var(--line-strong);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-3);
+    z-index: 401; overflow: hidden;
+  }
+  @supports not (backdrop-filter: blur(1px)) {
+    .cmdk-panel { background: var(--paper); }
+  }
+  .cmdk-input-wrap { display: flex; align-items: center; gap: 10px; padding: 14px 18px; border-bottom: 1px solid var(--line); }
+  .cmdk-input { flex: 1; font-size: 16px; background: transparent; border: none; outline: none; }
+  .cmdk-hint { font-family: var(--mono); font-size: 10px; color: var(--muted); border: 1px solid var(--line); padding: 2px 6px; border-radius: 4px; }
+  .cmdk-list { list-style: none; margin: 0; padding: 6px; max-height: 50vh; overflow-y: auto; }
+  .cmdk-item {
+    display: flex; align-items: center; gap: 10px;
+    width: 100%; padding: 9px 12px;
+    text-align: left; cursor: pointer; border-radius: 8px;
+    font-family: inherit; font-size: 14px;
+  }
+  .cmdk-item.active, .cmdk-item:hover { background: var(--paper-tint); }
+  .cmdk-item.active { background: var(--red-soft); color: var(--red); }
+  .cmdk-label { flex: 1; }
+  .cmdk-section { font-family: var(--mono); font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
+  .cmdk-shortcut { font-family: var(--mono); font-size: 10px; color: var(--muted); border: 1px solid var(--line); padding: 1px 5px; border-radius: 4px; }
+  .cmdk-empty { padding: 16px; text-align: center; color: var(--muted); font-size: 13px; }
+</style>

--- a/src/lib/components/Gantt.svelte
+++ b/src/lib/components/Gantt.svelte
@@ -177,6 +177,7 @@
       </div>
       {#if todayPos() !== null}
         <div class="gantt-today-line" style={`left:${todayPos()}px`}>
+          <span class="gantt-today-pulse"></span>
           <span class="gantt-today-label">Heute</span>
         </div>
       {/if}
@@ -310,6 +311,20 @@
     padding: 2px 6px; border-radius: 4px;
     text-transform: uppercase; letter-spacing: .04em;
     white-space: nowrap;
+  }
+  .gantt-today-pulse {
+    position: absolute; left: -3px; top: -3px;
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--red);
+    animation: pulse 2s ease-out infinite;
+  }
+  @keyframes pulse {
+    0%   { box-shadow: 0 0 0 0 rgba(227, 6, 19, 0.55); }
+    70%  { box-shadow: 0 0 0 14px rgba(227, 6, 19, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(227, 6, 19, 0); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .gantt-today-pulse { animation: none; }
   }
   .gantt-rows { position: relative; }
   .gantt-row { position: relative; height: 32px; border-bottom: 1px solid var(--line); }

--- a/src/lib/components/Gantt.svelte
+++ b/src/lib/components/Gantt.svelte
@@ -74,6 +74,23 @@
     return Math.max(8, (daysBetween(t.startDate, t.endDate) + 1) * dayWidth());
   }
 
+  function weekends(): { left: number; width: number }[] {
+    if (zoom === 'month') return []; // too dense to render
+    const out: { left: number; width: number }[] = [];
+    const start = parseDate(range.start);
+    const end = parseDate(range.end);
+    const cur = new Date(start);
+    while (cur <= end) {
+      const dow = cur.getDay();
+      if (dow === 0 || dow === 6) {
+        const left = daysBetween(range.start, fmtDate(cur)) * dayWidth();
+        out.push({ left, width: dayWidth() });
+      }
+      cur.setDate(cur.getDate() + 1);
+    }
+    return out;
+  }
+
   function months(): { label: string; left: number; width: number }[] {
     const out: { label: string; left: number; width: number }[] = [];
     const start = parseDate(range.start);
@@ -175,6 +192,9 @@
           <div class="gantt-axis-month" style={`left:${m.left}px;width:${m.width}px`}>{m.label}</div>
         {/each}
       </div>
+      {#each weekends() as w}
+        <div class="gantt-weekend" style={`left:${w.left}px;width:${w.width}px`}></div>
+      {/each}
       {#if todayPos() !== null}
         <div class="gantt-today-line" style={`left:${todayPos()}px`}>
           <span class="gantt-today-pulse"></span>
@@ -194,8 +214,13 @@
                 style={`left:${offsetPx(t.startDate) + (dragging?.id === t.id ? dragging.previewOffset : 0)}px;width:${widthFor(t)}px;background:${t.color ?? '#3B6CC4'}`}
                 onclick={() => { if (!dragging) onSelect?.(t.id); }}
                 onmousedown={(e) => onBarMouseDown(e, t)}
-                title={`${t.name} · ${t.startDate} → ${t.endDate}`}
-              >{t.name}</button>
+              >
+                <span class="gantt-bar-label">{t.name}</span>
+                <span class="gantt-bar-tooltip" role="tooltip">
+                  <span class="tooltip-name">{t.name}</span>
+                  <span class="tooltip-meta">{t.startDate} → {t.endDate}</span>
+                </span>
+              </button>
             {/if}
           </div>
         {/each}
@@ -299,6 +324,18 @@
     color: var(--ink); padding: 0 8px;
     white-space: nowrap; overflow: hidden;
   }
+  .gantt-weekend {
+    position: absolute; top: 60px; bottom: 0;
+    background: repeating-linear-gradient(
+      135deg,
+      rgba(15, 15, 16, 0.018) 0,
+      rgba(15, 15, 16, 0.018) 4px,
+      rgba(15, 15, 16, 0.04) 4px,
+      rgba(15, 15, 16, 0.04) 8px
+    );
+    pointer-events: none;
+    z-index: 1;
+  }
   .gantt-today-line {
     position: absolute; top: 30px; bottom: 0; width: 2px;
     background: var(--red); z-index: 8; pointer-events: none;
@@ -344,6 +381,27 @@
   .gantt-bar.critical { box-shadow: 0 0 0 2px var(--red), 0 1px 2px rgba(0,0,0,.1); }
   .gantt-bar.dragging { opacity: .7; cursor: grabbing; z-index: 9; }
   .gantt-bar { cursor: grab; }
+  .gantt-bar-label { display: block; }
+  .gantt-bar-tooltip {
+    position: absolute; bottom: calc(100% + 6px); left: 50%;
+    transform: translateX(-50%) scale(0.9);
+    background: var(--glass-dark);
+    -webkit-backdrop-filter: var(--blur-std);
+    backdrop-filter: var(--blur-std);
+    color: #fff;
+    padding: 6px 10px; border-radius: 8px;
+    box-shadow: var(--shadow-2);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity var(--d-fast) var(--ease-out-expo),
+                transform var(--d-fast) var(--ease-out-expo);
+    z-index: 30;
+    white-space: nowrap;
+    display: flex; flex-direction: column; gap: 2px;
+  }
+  .gantt-bar-tooltip .tooltip-name { font-family: var(--display); font-weight: 700; font-size: 12px; }
+  .gantt-bar-tooltip .tooltip-meta { font-family: var(--mono); font-size: 10px; opacity: 0.8; }
+  .gantt-bar:hover .gantt-bar-tooltip { opacity: 1; transform: translateX(-50%) scale(1); }
   .gantt-bar.summary {
     height: 8px; top: 12px; border-radius: 2px;
     background: linear-gradient(180deg, var(--ink) 0%, var(--ink-2) 100%);

--- a/src/lib/components/PhotoAnnotator.svelte
+++ b/src/lib/components/PhotoAnnotator.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+  /**
+   * Annotate a defect photo with red circle, arrow, freehand, text overlay.
+   * Outputs a new annotated JPG that's uploaded as a separate photo
+   * (the original stays untouched).
+   */
+  import Icon from './Icon.svelte';
+  import { compressImage } from '$lib/storage/photos';
+
+  type Tool = 'circle' | 'arrow' | 'freehand' | 'text' | 'stamp';
+  type Stroke = { tool: Tool; points: { x: number; y: number }[]; text?: string };
+
+  type Props = {
+    sourceUrl: string;
+    onCancel: () => void;
+    onSave: (annotated: Blob) => Promise<void> | void;
+  };
+  let { sourceUrl, onCancel, onSave }: Props = $props();
+
+  let canvasEl: HTMLCanvasElement;
+  let imgEl: HTMLImageElement | null = null;
+  let tool = $state<Tool>('circle');
+  let strokes = $state<Stroke[]>([]);
+  let drawing = $state(false);
+  let current: Stroke | null = null;
+  let saving = $state(false);
+  let textValue = $state('Mängel hier!');
+
+  const STAMPS = ['Mängel hier!', 'Siehe Foto', 'Nachbessern', 'Abnahme verweigert'];
+
+  $effect(() => {
+    if (!canvasEl) return;
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => {
+      imgEl = img;
+      // Fit canvas to a max of 1600px on the long edge while keeping aspect
+      const max = 1600;
+      const scale = Math.min(1, max / Math.max(img.width, img.height));
+      canvasEl.width = Math.round(img.width * scale);
+      canvasEl.height = Math.round(img.height * scale);
+      redraw();
+    };
+    img.src = sourceUrl;
+  });
+
+  function redraw() {
+    if (!canvasEl || !imgEl) return;
+    const ctx = canvasEl.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(imgEl, 0, 0, canvasEl.width, canvasEl.height);
+    for (const s of strokes) drawStroke(ctx, s);
+    if (current) drawStroke(ctx, current);
+  }
+
+  function drawStroke(ctx: CanvasRenderingContext2D, s: Stroke) {
+    ctx.strokeStyle = '#E30613';
+    ctx.lineWidth = Math.max(3, canvasEl.width / 400);
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.fillStyle = '#E30613';
+
+    if (s.tool === 'freehand') {
+      ctx.beginPath();
+      s.points.forEach((p, i) => (i === 0 ? ctx.moveTo(p.x, p.y) : ctx.lineTo(p.x, p.y)));
+      ctx.stroke();
+    } else if (s.tool === 'circle' && s.points.length >= 2) {
+      const a = s.points[0];
+      const b = s.points[s.points.length - 1];
+      const r = Math.hypot(b.x - a.x, b.y - a.y);
+      ctx.beginPath();
+      ctx.arc(a.x, a.y, r, 0, 2 * Math.PI);
+      ctx.stroke();
+    } else if (s.tool === 'arrow' && s.points.length >= 2) {
+      const a = s.points[0];
+      const b = s.points[s.points.length - 1];
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const ang = Math.atan2(dy, dx);
+      const head = Math.max(14, canvasEl.width / 50);
+      ctx.beginPath();
+      ctx.moveTo(a.x, a.y); ctx.lineTo(b.x, b.y);
+      ctx.lineTo(b.x - head * Math.cos(ang - Math.PI / 6), b.y - head * Math.sin(ang - Math.PI / 6));
+      ctx.moveTo(b.x, b.y);
+      ctx.lineTo(b.x - head * Math.cos(ang + Math.PI / 6), b.y - head * Math.sin(ang + Math.PI / 6));
+      ctx.stroke();
+    } else if ((s.tool === 'text' || s.tool === 'stamp') && s.points.length >= 1 && s.text) {
+      const p = s.points[0];
+      const size = Math.max(20, canvasEl.width / 30);
+      ctx.font = `700 ${size}px Inter, system-ui, sans-serif`;
+      const m = ctx.measureText(s.text);
+      const padding = size * 0.3;
+      const w = m.width + padding * 2;
+      const h = size + padding * 1.2;
+      ctx.fillStyle = '#E30613';
+      ctx.fillRect(p.x - w / 2, p.y - h / 2, w, h);
+      ctx.fillStyle = '#fff';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(s.text, p.x, p.y);
+    }
+  }
+
+  function pointerToCanvas(e: PointerEvent): { x: number; y: number } {
+    const rect = canvasEl.getBoundingClientRect();
+    return {
+      x: ((e.clientX - rect.left) / rect.width) * canvasEl.width,
+      y: ((e.clientY - rect.top) / rect.height) * canvasEl.height
+    };
+  }
+
+  function onDown(e: PointerEvent) {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    drawing = true;
+    canvasEl.setPointerCapture(e.pointerId);
+    const p = pointerToCanvas(e);
+    if (tool === 'text' || tool === 'stamp') {
+      current = { tool, points: [p], text: textValue };
+      strokes = [...strokes, current];
+      current = null;
+      drawing = false;
+      redraw();
+      return;
+    }
+    current = { tool, points: [p] };
+    redraw();
+  }
+  function onMove(e: PointerEvent) {
+    if (!drawing || !current) return;
+    current.points.push(pointerToCanvas(e));
+    redraw();
+  }
+  function onUp() {
+    if (current) {
+      strokes = [...strokes, current];
+      current = null;
+    }
+    drawing = false;
+  }
+
+  function undo() {
+    strokes = strokes.slice(0, -1);
+    redraw();
+  }
+  function clearAll() {
+    strokes = [];
+    redraw();
+  }
+
+  async function save() {
+    if (!canvasEl) return;
+    saving = true;
+    try {
+      const blob = await new Promise<Blob>((resolve, reject) =>
+        canvasEl.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob failed'))), 'image/jpeg', 0.85)
+      );
+      // Re-compress to ensure 1600px max + 0.78 quality consistency
+      const file = new File([blob], 'annotated.jpg', { type: 'image/jpeg' });
+      const { blob: reBlob } = await compressImage(file);
+      await onSave(reBlob);
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<div class="annotator">
+  <div class="annotator-toolbar">
+    <button class="btn btn-ghost btn-sm" onclick={onCancel}>Abbrechen</button>
+    <div class="tools">
+      {#each (['circle', 'arrow', 'freehand', 'stamp'] as const) as t}
+        <button class="tool-btn" class:active={tool === t} onclick={() => (tool = t)} aria-label={t}>
+          {#if t === 'circle'}◯{:else if t === 'arrow'}↗{:else if t === 'freehand'}✎{:else}✖{/if}
+        </button>
+      {/each}
+    </div>
+    <button class="btn btn-ghost btn-sm" onclick={undo} disabled={strokes.length === 0}>↶ Zurück</button>
+    <button class="btn btn-ghost btn-sm" onclick={clearAll} disabled={strokes.length === 0}>Alle löschen</button>
+    <button class="btn btn-primary btn-sm" onclick={save} disabled={saving || strokes.length === 0}>
+      {saving ? 'Speichert…' : 'Speichern'}
+    </button>
+  </div>
+  {#if tool === 'stamp'}
+    <div class="stamp-bar">
+      {#each STAMPS as s}
+        <button class="stamp" class:active={textValue === s} onclick={() => (textValue = s)}>{s}</button>
+      {/each}
+    </div>
+  {/if}
+  <div class="canvas-wrap-anno">
+    <canvas
+      bind:this={canvasEl}
+      onpointerdown={onDown}
+      onpointermove={onMove}
+      onpointerup={onUp}
+      onpointercancel={onUp}
+      style="touch-action:none"
+    ></canvas>
+  </div>
+</div>
+
+<style>
+  .annotator {
+    position: fixed; inset: 0; z-index: 250;
+    background: rgba(15, 15, 16, 0.95);
+    -webkit-backdrop-filter: var(--blur-std);
+    backdrop-filter: var(--blur-std);
+    display: flex; flex-direction: column;
+  }
+  .annotator-toolbar {
+    display: flex; gap: 8px; align-items: center;
+    padding: 12px 14px; background: var(--glass-dark);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    flex-wrap: wrap;
+  }
+  .tools { display: flex; gap: 4px; background: rgba(255, 255, 255, 0.08); padding: 3px; border-radius: 8px; }
+  .tool-btn { width: 36px; height: 36px; border-radius: 6px; color: #fff; font-size: 16px; cursor: pointer; }
+  .tool-btn:hover { background: rgba(255, 255, 255, 0.16); }
+  .tool-btn.active { background: var(--red); }
+  .stamp-bar { display: flex; gap: 6px; padding: 8px 14px; background: rgba(255, 255, 255, 0.04); overflow-x: auto; }
+  .stamp { padding: 6px 12px; border-radius: 999px; background: rgba(255, 255, 255, 0.08); color: #fff; font-size: 12px; cursor: pointer; white-space: nowrap; font-family: inherit; }
+  .stamp.active { background: var(--red); }
+  .canvas-wrap-anno { flex: 1; overflow: auto; display: flex; align-items: center; justify-content: center; padding: 12px; }
+  .canvas-wrap-anno canvas { max-width: 100%; max-height: 100%; display: block; touch-action: none; cursor: crosshair; }
+</style>

--- a/src/lib/components/PinPreview.svelte
+++ b/src/lib/components/PinPreview.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  /** Floating preview-card on the plan-viewer when a pin is tapped. */
+  import Icon from './Icon.svelte';
+  import { getSignedUrl } from '$lib/storage/photos';
+  import { fly } from 'svelte/transition';
+  import { ease } from '$lib/motion';
+
+  type Props = {
+    defectId: string;
+    projectId: string;
+    shortId: string | null;
+    title: string;
+    status: string;
+    gewerkColor: string | null;
+    photoStoragePath: string | null;
+    x: number; // pixel
+    y: number; // pixel
+    onOpen: () => void;
+    onClose: () => void;
+    onChangeStatus?: (s: string) => void;
+  };
+  let { defectId, projectId, shortId, title, status, gewerkColor, photoStoragePath, x, y, onOpen, onClose, onChangeStatus }: Props = $props();
+
+  let imgUrl = $state<string | null>(null);
+  let menuOpen = $state(false);
+  $effect(() => {
+    if (photoStoragePath) {
+      getSignedUrl('defect-photos', photoStoragePath, 600).then((u) => (imgUrl = u));
+    } else {
+      imgUrl = null;
+    }
+  });
+
+  const STATUS_LABELS: Record<string, string> = {
+    open: 'Offen', sent: 'Gesendet', acknowledged: 'Bestätigt',
+    resolved: 'Erledigt', accepted: 'Akzeptiert', rejected: 'Abgelehnt', reopened: 'Wiedereröffnet'
+  };
+</script>
+
+<div
+  class="pin-preview"
+  style:left={`${x}px`}
+  style:top={`${y}px`}
+  in:fly|local={{ y: -8, duration: 220, easing: ease.outExpo }}
+  role="dialog"
+  aria-label="Mangel-Vorschau"
+>
+  <button class="pin-preview-close" onclick={onClose} aria-label="Schließen">
+    <Icon name="close" size={14} />
+  </button>
+  <div class="pin-preview-inner">
+    <span class="pin-preview-stripe" style:background={gewerkColor ?? 'var(--red)'}></span>
+    <div class="pin-preview-text">
+      <span class="pin-preview-id">{shortId ?? '—'}</span>
+      <span class="pin-preview-title">{title}</span>
+      <span class="pin-preview-status status-{status}">{STATUS_LABELS[status] ?? status}</span>
+    </div>
+    {#if imgUrl}
+      <button class="pin-preview-img" onclick={onOpen} aria-label="Foto öffnen">
+        <img src={imgUrl} alt="Foto" />
+      </button>
+    {/if}
+  </div>
+  <div class="pin-preview-actions">
+    <button class="btn btn-ghost btn-sm" onclick={onOpen}>
+      <Icon name="eye" size={14} /> Details
+    </button>
+    {#if onChangeStatus}
+      <button class="btn btn-ghost btn-sm" onclick={() => (menuOpen = !menuOpen)} aria-label="Status">
+        <Icon name="more" size={14} />
+      </button>
+      {#if menuOpen}
+        <div class="pin-preview-menu">
+          {#each [['acknowledged', 'Bestätigt'], ['resolved', 'Erledigt'], ['accepted', 'Akzeptiert'], ['rejected', 'Abgelehnt']] as [s, label]}
+            <button class="menu-item" onclick={() => { onChangeStatus(s); menuOpen = false; }}>{label}</button>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .pin-preview {
+    position: absolute;
+    transform: translate(-50%, calc(-100% - 28px));
+    background: var(--glass-light);
+    -webkit-backdrop-filter: var(--blur-std);
+    backdrop-filter: var(--blur-std);
+    border: 1px solid var(--line-strong);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-3);
+    width: 240px;
+    z-index: 30;
+    overflow: hidden;
+  }
+  @supports not (backdrop-filter: blur(1px)) {
+    .pin-preview { background: var(--paper); }
+  }
+  .pin-preview-close {
+    position: absolute; top: 6px; right: 6px;
+    width: 22px; height: 22px;
+    background: rgba(15, 15, 16, .12); color: var(--ink);
+    border-radius: 50%; display: flex; align-items: center; justify-content: center;
+    cursor: pointer; z-index: 1;
+  }
+  .pin-preview-inner { display: flex; gap: 10px; padding: 10px; align-items: center; }
+  .pin-preview-stripe { width: 4px; align-self: stretch; border-radius: 2px; }
+  .pin-preview-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+  .pin-preview-id { font-family: var(--mono); font-size: 10px; font-weight: 700; color: var(--muted); }
+  .pin-preview-title { font-family: var(--display); font-weight: 700; font-size: 13px; line-height: 1.2; }
+  .pin-preview-status { font-family: var(--mono); font-size: 9px; font-weight: 700; padding: 2px 6px; border-radius: 999px; align-self: flex-start; text-transform: uppercase; letter-spacing: .04em; }
+  .pin-preview-img { width: 56px; height: 56px; border-radius: 8px; overflow: hidden; padding: 0; border: 1px solid var(--line); flex-shrink: 0; cursor: zoom-in; }
+  .pin-preview-img img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .pin-preview-actions { display: flex; gap: 4px; padding: 6px 10px 10px; position: relative; }
+  .pin-preview-menu {
+    position: absolute; bottom: 100%; right: 6px; background: var(--paper);
+    border: 1px solid var(--line); border-radius: var(--r-md);
+    box-shadow: var(--shadow-2); overflow: hidden;
+    display: flex; flex-direction: column; min-width: 140px;
+    margin-bottom: 4px;
+  }
+  .menu-item { padding: 8px 12px; text-align: left; font-size: 13px; cursor: pointer; }
+  .menu-item:hover { background: var(--paper-tint); }
+  .status-open, .status-reopened { background: var(--red-soft); color: var(--red); }
+  .status-sent, .status-acknowledged { background: var(--amber-soft); color: var(--amber); }
+  .status-resolved, .status-accepted { background: var(--green-soft); color: var(--green); }
+  .status-rejected { background: var(--grey-soft); color: var(--muted); }
+</style>

--- a/src/lib/components/Sheet.svelte
+++ b/src/lib/components/Sheet.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  /**
+   * Reusable bottom-sheet with frosted-top, drag-to-close, ESC-close.
+   * Pass children via the default slot. Title goes in the `head` snippet.
+   *
+   * Usage:
+   *   <Sheet bind:open ariaLabel="Mangel anlegen">
+   *     {#snippet head()}<h3 class="sheet-title">Titel</h3>{/snippet}
+   *     {#snippet body()}…{/snippet}
+   *     {#snippet foot()}…{/snippet}
+   *   </Sheet>
+   */
+  import Icon from './Icon.svelte';
+  import { haptic } from '$lib/motion';
+  import { onMount } from 'svelte';
+  import type { Snippet } from 'svelte';
+
+  type Props = {
+    open: boolean;
+    ariaLabel?: string;
+    eyebrow?: string;
+    title?: string;
+    head?: Snippet;
+    body?: Snippet;
+    foot?: Snippet;
+    children?: Snippet;
+    onClose?: () => void;
+  };
+  let {
+    open = $bindable(),
+    ariaLabel = 'Sheet',
+    eyebrow,
+    title,
+    head,
+    body,
+    foot,
+    children,
+    onClose
+  }: Props = $props();
+
+  let dragY = $state(0);
+  let dragging = $state(false);
+  let startY = 0;
+  let sheetEl: HTMLElement | null = $state(null);
+
+  function close() {
+    haptic(6);
+    open = false;
+    onClose?.();
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    dragging = true;
+    startY = e.clientY;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }
+  function onPointerMove(e: PointerEvent) {
+    if (!dragging) return;
+    const dy = e.clientY - startY;
+    dragY = Math.max(0, dy);
+  }
+  function onPointerUp(_: PointerEvent) {
+    if (!dragging) return;
+    dragging = false;
+    if (dragY > 100) close();
+    dragY = 0;
+  }
+
+  onMount(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape' && open) close();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
+</script>
+
+{#if open}
+  <button class="scrim open" onclick={close} aria-label="Schließen"></button>
+{/if}
+<div
+  bind:this={sheetEl}
+  class="sheet"
+  class:open
+  class:dragging
+  role="dialog"
+  aria-label={ariaLabel}
+  aria-modal="true"
+  style:transform={dragY > 0 && open ? `translateY(${dragY}px)` : undefined}
+>
+  <div
+    class="sheet-handle-area"
+    onpointerdown={onPointerDown}
+    onpointermove={onPointerMove}
+    onpointerup={onPointerUp}
+    onpointercancel={onPointerUp}
+    role="presentation"
+  >
+    <div class="sheet-handle"></div>
+  </div>
+  {#if head || title || eyebrow}
+    <div class="sheet-head">
+      <div class="sheet-head-text">
+        {#if eyebrow}<div class="sheet-eyebrow">{eyebrow}</div>{/if}
+        {#if title}<h3 class="sheet-title">{title}</h3>{/if}
+        {#if head}{@render head()}{/if}
+      </div>
+      <button class="sheet-close" onclick={close} aria-label="Schließen"><Icon name="close" /></button>
+    </div>
+  {/if}
+  {#if body}
+    <div class="sheet-body">{@render body()}</div>
+  {:else if children}
+    <div class="sheet-body">{@render children()}</div>
+  {/if}
+  {#if foot}
+    <div class="sheet-foot">{@render foot()}</div>
+  {/if}
+</div>

--- a/src/lib/components/Skeleton.svelte
+++ b/src/lib/components/Skeleton.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  type Props = { rows?: number; height?: number; gap?: number };
+  let { rows = 3, height = 48, gap = 8 }: Props = $props();
+</script>
+
+<div class="skeleton-list" style:gap={`${gap}px`}>
+  {#each Array(rows) as _, i (i)}
+    <div class="skeleton-row" style:height={`${height}px`}></div>
+  {/each}
+</div>
+
+<style>
+  .skeleton-list { display: flex; flex-direction: column; }
+  .skeleton-row {
+    background: linear-gradient(90deg, var(--paper-tint) 0%, var(--grey-soft) 50%, var(--paper-tint) 100%);
+    background-size: 200% 100%;
+    border-radius: var(--r-md);
+    animation: shimmer 1.4s linear infinite;
+  }
+  @keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton-row { animation: none; background: var(--grey-soft); }
+  }
+</style>

--- a/src/lib/components/VoiceInput.svelte
+++ b/src/lib/components/VoiceInput.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  /**
+   * Microphone button that uses Web Speech API to dictate German text
+   * into a target field. Falls back gracefully if API is missing.
+   */
+  import Icon from './Icon.svelte';
+  import { toast } from './Toast.svelte';
+  import { haptic } from '$lib/motion';
+
+  type Props = {
+    onResult: (text: string) => void;
+    lang?: string;
+  };
+  let { onResult, lang = 'de-DE' }: Props = $props();
+
+  let listening = $state(false);
+  let supported = $state(false);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let recognition: any = null;
+
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const SR = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    supported = !!SR;
+  });
+
+  function start() {
+    if (typeof window === 'undefined') return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const SR = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (!SR) {
+      toast('Spracheingabe vom Browser nicht unterstützt.');
+      return;
+    }
+    recognition = new SR();
+    recognition.lang = lang;
+    recognition.continuous = false;
+    recognition.interimResults = true;
+    let finalText = '';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    recognition.onresult = (e: any) => {
+      let interim = '';
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        const t = e.results[i][0].transcript;
+        if (e.results[i].isFinal) finalText += t;
+        else interim += t;
+      }
+      onResult(finalText + interim);
+    };
+    recognition.onerror = () => {
+      listening = false;
+      toast('Aufnahme abgebrochen.');
+    };
+    recognition.onend = () => {
+      listening = false;
+      if (finalText) haptic(15);
+    };
+    listening = true;
+    haptic(10);
+    recognition.start();
+  }
+
+  function stop() {
+    recognition?.stop();
+    listening = false;
+  }
+</script>
+
+{#if supported}
+  <button
+    class="voice-btn"
+    class:listening
+    onclick={() => (listening ? stop() : start())}
+    aria-label={listening ? 'Aufnahme stoppen' : 'Diktieren'}
+    type="button"
+  >
+    {#if listening}
+      <span class="voice-pulse"></span>
+      <Icon name="check" size={14} />
+    {:else}
+      <span class="voice-icon">●</span>
+    {/if}
+  </button>
+{/if}
+
+<style>
+  .voice-btn {
+    width: 36px; height: 36px; border-radius: 50%;
+    background: var(--paper-tint); border: 1px solid var(--line-strong);
+    display: inline-flex; align-items: center; justify-content: center;
+    cursor: pointer; flex-shrink: 0;
+    color: var(--muted);
+    position: relative;
+  }
+  .voice-btn:hover { color: var(--red); border-color: var(--red); }
+  .voice-btn.listening { background: var(--red); color: #fff; border-color: var(--red); }
+  .voice-icon { font-size: 12px; }
+  .voice-pulse {
+    position: absolute; inset: -3px;
+    border-radius: 50%;
+    border: 2px solid var(--red);
+    animation: voicepulse 1.4s ease-out infinite;
+  }
+  @keyframes voicepulse {
+    0%   { transform: scale(0.7); opacity: 1; }
+    100% { transform: scale(1.4); opacity: 0; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .voice-pulse { animation: none; }
+  }
+</style>

--- a/src/lib/db/defectQueries.ts
+++ b/src/lib/db/defectQueries.ts
@@ -221,6 +221,7 @@ export async function getPlan(projectId: string, planId: string) {
       page: defects.page,
       xPct: defects.xPct,
       yPct: defects.yPct,
+      gewerkId: defects.gewerkId,
       gewerkColor: gewerke.color
     })
     .from(defects)

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -250,6 +250,7 @@ export const defectPhotos = pgTable('defect_photos', {
   defectId: uuid('defect_id').notNull().references(() => defects.id, { onDelete: 'cascade' }),
   storagePath: text('storage_path').notNull(),
   caption: text('caption'),
+  sortOrder: integer('sort_order').default(0).notNull(),
   uploadedBy: uuid('uploaded_by').references(() => profiles.id),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
@@ -300,6 +301,17 @@ export const musterdetails = pgTable('musterdetails', {
   label: text('label').notNull(),
   storagePath: text('storage_path').notNull(),
   uploadedBy: uuid('uploaded_by').references(() => profiles.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+});
+
+/* ----- Textbausteine (defect-text snippets per gewerk) ----- */
+
+export const textbausteine = pgTable('textbausteine', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  gewerkId: uuid('gewerk_id').references(() => gewerke.id, { onDelete: 'cascade' }),
+  label: text('label').notNull(),
+  body: text('body').notNull(),
+  sortOrder: integer('sort_order').default(0).notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,84 @@
+/**
+ * Motion primitives — Spring-feeling transitions for Svelte.
+ * Prefers reduced-motion is respected via the `respectReducedMotion` flag.
+ */
+import { cubicOut, expoOut, quintOut } from 'svelte/easing';
+import type { TransitionConfig } from 'svelte/transition';
+
+const reducedMotion = (): boolean =>
+  typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+/* ---------- Easing curves (matching docs/UX_AUDIT.md §0) ---------- */
+export const ease = {
+  outExpo: expoOut,
+  outQuint: quintOut,
+  outCubic: cubicOut,
+  spring: (t: number) => {
+    // Apple-ish damped spring: starts fast, overshoots subtly then settles
+    return 1 - Math.exp(-6 * t) * Math.cos(8 * t);
+  }
+} as const;
+
+/* ---------- Durations ---------- */
+export const dur = {
+  micro: 120,
+  fast: 180,
+  std: 220,
+  page: 400
+} as const;
+
+/* ---------- Slide-up transition (sheets) ---------- */
+export function sheetIn(node: HTMLElement, params: { duration?: number } = {}): TransitionConfig {
+  const d = reducedMotion() ? dur.fast : params.duration ?? 320;
+  return {
+    duration: d,
+    easing: ease.outExpo,
+    css: (t) => {
+      const offset = (1 - t) * 100;
+      return `transform: translateY(${offset}%); opacity: ${0.6 + t * 0.4};`;
+    }
+  };
+}
+
+/* ---------- Scale-fade (cards, dialogs, lightbox) ---------- */
+export function pop(node: HTMLElement, params: { duration?: number; from?: number } = {}): TransitionConfig {
+  const d = reducedMotion() ? dur.fast : params.duration ?? dur.std;
+  const from = params.from ?? 0.94;
+  return {
+    duration: d,
+    easing: ease.outExpo,
+    css: (t) => {
+      const s = from + (1 - from) * t;
+      return `transform: scale(${s}); opacity: ${t};`;
+    }
+  };
+}
+
+/* ---------- Subtle bounce on tap ---------- */
+export function press(node: HTMLElement, _: unknown): TransitionConfig {
+  return {
+    duration: 180,
+    easing: ease.spring,
+    css: (t) => `transform: scale(${0.97 + t * 0.03});`
+  };
+}
+
+/* ---------- Stagger fade-in for list items ---------- */
+export function fadeUp(node: HTMLElement, params: { delay?: number; y?: number } = {}): TransitionConfig {
+  const d = reducedMotion() ? dur.fast : 320;
+  const y = params.y ?? 8;
+  return {
+    duration: d,
+    delay: params.delay ?? 0,
+    easing: ease.outExpo,
+    css: (t) => `transform: translateY(${(1 - t) * y}px); opacity: ${t};`
+  };
+}
+
+/* ---------- Haptic (no-op on desktop) ---------- */
+export function haptic(ms = 8) {
+  if (typeof window === 'undefined') return;
+  if (reducedMotion()) return;
+  const v = (window.navigator as unknown as { vibrate?: (n: number) => boolean }).vibrate;
+  if (typeof v === 'function') v(ms);
+}

--- a/src/lib/seed/textbausteine.ts
+++ b/src/lib/seed/textbausteine.ts
@@ -1,0 +1,64 @@
+/**
+ * Standard-Mängel-Textbausteine pro Gewerk (Phase C3).
+ * Bauleiter wählt im Defect-Editor "Textbaustein einfügen" → Body wird in
+ * description-Feld geschrieben.
+ *
+ * Quelle: gängige Mängel aus der VOB-Praxis. Anpassbar via DB oder Re-Seed.
+ */
+export type TextbausteinSeed = {
+  gewerk: string; // matched against gewerke.name at seed-time
+  label: string;
+  body: string;
+};
+
+export const TEXTBAUSTEINE_SEED: TextbausteinSeed[] = [
+  // Maler
+  { gewerk: 'Maler', label: 'Putz nicht eben', body: 'Der Putz ist nicht eben aufgetragen — Wellenbildung sichtbar. Bitte abschleifen und neu beschichten.' },
+  { gewerk: 'Maler', label: 'Anstrich ungleichmäßig', body: 'Anstrich deckt nicht gleichmäßig — Schattierungen / Streifen sichtbar. Bitte zweiten Anstrich auftragen.' },
+  { gewerk: 'Maler', label: 'Farbspritzer', body: 'Farbspritzer auf Boden / Steckdose / Fenster. Bitte fachgerecht entfernen.' },
+  { gewerk: 'Maler', label: 'Übergang Decke', body: 'Übergang Wand zu Decke nicht sauber gezogen — Linie wellig. Nachbessern.' },
+
+  // Fliesenleger
+  { gewerk: 'Fliesenleger', label: 'Fugenbild ungleichmäßig', body: 'Fugenbreite variiert deutlich. Fliesen aufnehmen und neu verlegen.' },
+  { gewerk: 'Fliesenleger', label: 'Silikonfuge unsauber', body: 'Silikonfuge weist Risse / Lücken auf. Bitte vollständig erneuern.' },
+  { gewerk: 'Fliesenleger', label: 'Fliese gebrochen', body: 'Fliese ist gebrochen / abgeplatzt. Austauschen.' },
+  { gewerk: 'Fliesenleger', label: 'Bodenablauf nicht bündig', body: 'Bodenablauf liegt nicht bündig zur Fliesenoberkante — Wasserstau möglich. Korrigieren.' },
+
+  // Elektro
+  { gewerk: 'Elektro', label: 'Steckdose schief', body: 'Steckdose nicht waagerecht montiert. Bitte ausrichten.' },
+  { gewerk: 'Elektro', label: 'FI fehlt / defekt', body: 'FI-Schutzschalter fehlt oder löst nicht aus. Prüfen und ersetzen, Prüfprotokoll mitliefern.' },
+  { gewerk: 'Elektro', label: 'Lichtschalter ohne Funktion', body: 'Lichtschalter ohne Funktion. Verkabelung prüfen.' },
+  { gewerk: 'Elektro', label: 'Kabelende nicht eingeführt', body: 'Kabelende lose / nicht in Dose eingeführt. Fertig anschließen.' },
+
+  // Sanitär/Heizung
+  { gewerk: 'Sanitär/Heizung', label: 'Mischer tropft', body: 'Mischbatterie tropft. Dichtung erneuern.' },
+  { gewerk: 'Sanitär/Heizung', label: 'WC nicht fest', body: 'WC sitzt nicht fest am Boden. Befestigung nachziehen.' },
+  { gewerk: 'Sanitär/Heizung', label: 'Heizkörper kalt', body: 'Heizkörper wird oben kalt. Entlüften und Funktion prüfen.' },
+  { gewerk: 'Sanitär/Heizung', label: 'Ablauf riecht', body: 'Geruch aus Bodenablauf — Geruchsverschluss prüfen.' },
+
+  // Trockenbau
+  { gewerk: 'Trockenbau', label: 'Spachtelung sichtbar', body: 'Spachtelübergänge zwischen Platten klar sichtbar. Q3-Spachtelung erforderlich.' },
+  { gewerk: 'Trockenbau', label: 'Wand nicht lotrecht', body: 'Trockenbauwand nicht lotrecht. Korrigieren.' },
+
+  // Parkett
+  { gewerk: 'Parkett', label: 'Sockelleiste lose', body: 'Sockelleiste löst sich von der Wand. Neu befestigen.' },
+  { gewerk: 'Parkett', label: 'Dehnungsfuge fehlt', body: 'Keine Dehnungsfuge zur Wand erkennbar — bei Klima-Belastung Verformungsrisiko. Fuge anlegen.' },
+  { gewerk: 'Parkett', label: 'Kratzer in Oberfläche', body: 'Tiefer Kratzer in Parkettoberfläche — vermutlich durch Folgegewerk. Schleifen + neu versiegeln.' },
+
+  // Türen
+  { gewerk: 'Türen', label: 'Tür schleift', body: 'Tür schleift am Boden / Zarge. Höhe einstellen oder Türblatt kürzen.' },
+  { gewerk: 'Türen', label: 'Schließblech versetzt', body: 'Schließblech sitzt versetzt — Tür schließt nicht richtig. Justieren.' },
+  { gewerk: 'Türen', label: 'Dichtung lose', body: 'Türdichtung löst sich umlaufend. Erneuern.' },
+
+  // Fenster
+  { gewerk: 'Fenster', label: 'Fugenanschluss undicht', body: 'Anschluss Fenster zu Mauerwerk nicht winddicht — Zugluft. Fugenband nacharbeiten.' },
+  { gewerk: 'Fenster', label: 'Fenster schließt nicht', body: 'Fensterflügel schließt nicht spaltfrei. Beschlag justieren.' },
+
+  // Rohbau
+  { gewerk: 'Rohbau', label: 'Beton nicht eben', body: 'Bodenplatte / Decke weist Unebenheiten > 5mm auf. Spachteln oder abschleifen.' },
+  { gewerk: 'Rohbau', label: 'Mauerwerksfuge offen', body: 'Mauerwerksfuge nicht vollständig vermörtelt. Verschließen.' },
+
+  // Außenanlagen
+  { gewerk: 'Außenanlagen', label: 'Pflaster lose', body: 'Pflasterstein liegt lose / wackelt. Neu setzen.' },
+  { gewerk: 'Außenanlagen', label: 'Gefälle falsch', body: 'Pflasterfläche hat Gegengefälle — Wasser läuft zum Gebäude. Aufnehmen und neu verlegen.' }
+];

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import Toast from '$lib/components/Toast.svelte';
+  import CommandPalette from '$lib/components/CommandPalette.svelte';
 
   let { children } = $props();
 </script>
 
 {@render children()}
 <Toast />
+<CommandPalette />

--- a/src/routes/(app)/[projectId]/aufgaben/+page.svelte
+++ b/src/routes/(app)/[projectId]/aufgaben/+page.svelte
@@ -94,7 +94,7 @@
         </h3>
         <div class="aufgabe-list">
           {#each grouped[group] as a (a.id)}
-            <a class="aufgabe-card" href={a.href}>
+            <a class="aufgabe-card" href={a.href} data-overdue={a.daysFromToday < 0} data-prio={a.priority}>
               <span class="aufgabe-stripe" style={`background:${a.gewerkColor ?? '#6B6660'}`}></span>
               <span class="aufgabe-body">
                 <span class="aufgabe-line1">
@@ -126,8 +126,10 @@
   .aufgabe-group.overdue { color: var(--red); }
   .aufgabe-group .count { font-family: var(--mono); font-size: 11px; }
   .aufgabe-list { display: flex; flex-direction: column; gap: 6px; }
-  .aufgabe-card { display: flex; gap: 10px; background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); padding: 10px 12px; align-items: center; text-decoration: none; color: inherit; transition: all .12s; }
-  .aufgabe-card:hover { border-color: var(--line-strong); transform: translateX(2px); }
+  .aufgabe-card { display: flex; gap: 10px; background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); padding: 10px 12px; align-items: center; text-decoration: none; color: inherit; }
+  .aufgabe-card:hover { border-color: var(--line-strong); transform: translateY(-1px); box-shadow: var(--shadow-1); }
+  .aufgabe-card[data-overdue="true"] { background: linear-gradient(to right, var(--tint-red), var(--paper) 35%); border-left: 3px solid var(--red); }
+  .aufgabe-card[data-prio="1"] .aufgabe-title { font-weight: 800; }
   .aufgabe-stripe { width: 4px; align-self: stretch; border-radius: 2px; flex-shrink: 0; }
   .aufgabe-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
   .aufgabe-line1 { display: flex; align-items: baseline; gap: 6px; flex-wrap: wrap; }

--- a/src/routes/(app)/[projectId]/dashboard/+page.svelte
+++ b/src/routes/(app)/[projectId]/dashboard/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Icon from '$lib/components/Icon.svelte';
   import { timeAgo } from '$lib/util/time';
+  import { onMount } from 'svelte';
 
   let { data } = $props();
   let parent = $derived(data);
@@ -10,6 +11,47 @@
     .join(' · ') || 'Noch keine Häuser');
 
   let stats = $derived(parent.stats ?? { checklistsDone: 0, defectsOpen: 0, taskCount: 0 });
+
+  // Project progress: rough heuristic — done checklist items / (done + open defects + open tasks)
+  let percentTarget = $derived(() => {
+    const total = stats.checklistsDone + stats.defectsOpen + stats.taskCount;
+    if (total === 0) return 0;
+    return Math.min(100, Math.round((stats.checklistsDone / total) * 100));
+  });
+
+  let displayPercent = $state(0);
+  onMount(() => {
+    // Counter animation on mount
+    const target = percentTarget();
+    const start = performance.now();
+    const dur = 900;
+    function tick(now: number) {
+      const t = Math.min(1, (now - start) / dur);
+      const eased = 1 - Math.pow(1 - t, 3); // cubic-out
+      displayPercent = Math.round(target * eased);
+      if (t < 1) requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  });
+
+  // Stroke-dashoffset: circumference 2πr where r=34
+  const C = 2 * Math.PI * 34; // 213.628
+  let dashOffset = $derived(C - (displayPercent / 100) * C);
+
+  // Avatar colors per profile id (deterministic hash)
+  function avatarColor(id: string | null | undefined): string {
+    if (!id) return 'var(--grey)';
+    let h = 0;
+    for (const c of id) h = (h << 5) - h + c.charCodeAt(0);
+    const palette = ['#E8833A', '#3B6CC4', '#3FAA60', '#D4A22A', '#7A7570', '#C9482F', '#1E96A8', '#7CB246', '#9F4EAB'];
+    return palette[Math.abs(h) % palette.length];
+  }
+  function initials(name: string | null | undefined): string {
+    if (!name) return '·';
+    const parts = name.trim().split(/\s+/);
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
 </script>
 
 <div class="page">
@@ -21,9 +63,9 @@
       <div class="progress-ring">
         <svg viewBox="0 0 80 80">
           <circle class="ring-bg" cx="40" cy="40" r="34" />
-          <circle class="ring-fg" cx="40" cy="40" r="34" stroke-dasharray="213" stroke-dashoffset="213" />
+          <circle class="ring-fg" cx="40" cy="40" r="34" stroke-dasharray={C} stroke-dashoffset={dashOffset} />
         </svg>
-        <div class="progress-ring-label">0%</div>
+        <div class="progress-ring-label">{displayPercent}%</div>
       </div>
       <div class="hero-stats">
         <div>
@@ -89,12 +131,17 @@
     <div class="activity-feed">
       {#each parent.recent as a (a.id)}
         <div class="activity-item">
-          <span class="activity-icon" class:photo={a.type === 'photo'} class:defect={a.type === 'defect'}>
-            <Icon name={a.type === 'photo' ? 'photo' : a.type === 'defect' ? 'defect' : 'check'} size={15} />
+          <span class="avatar" style:background={avatarColor(a.userName)}>
+            {initials(a.userName)}
           </span>
           <span class="activity-text">
-            <span class="activity-line1">{a.message}</span>
-            <span class="activity-line2">{a.userName ?? 'System'} · {timeAgo(a.ts)}</span>
+            <span class="activity-line1">
+              <b>{a.userName ?? 'System'}</b> {a.message}
+            </span>
+            <span class="activity-line2">
+              <Icon name={a.type === 'photo' ? 'photo' : a.type === 'defect' ? 'defect' : a.type === 'task_moved' ? 'gantt' : 'check'} size={11} />
+              {timeAgo(a.ts)}
+            </span>
           </span>
         </div>
       {/each}
@@ -119,4 +166,14 @@
     background: var(--red-soft); color: var(--red);
     display: flex; align-items: center; justify-content: center;
   }
+  .avatar {
+    width: 30px; height: 30px; border-radius: 50%;
+    color: #fff; flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center;
+    font-family: var(--display); font-weight: 700; font-size: 11px;
+    letter-spacing: 0.02em;
+  }
+  .activity-line1 :global(b) { font-weight: 700; color: var(--ink); }
+  .activity-line2 { display: inline-flex; align-items: center; gap: 5px; }
+  .activity-line2 :global(svg) { color: var(--muted); }
 </style>

--- a/src/routes/(app)/[projectId]/maengel/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/+page.svelte
@@ -137,24 +137,33 @@
       <div class="empty-text">Keine Mängel in diesem Filter.</div>
     </div>
   {:else}
-    <div class="defect-list">
-      {#each visible as d (d.id)}
-        <a class="defect-card" href={`/${parent.project.id}/maengel/${d.id}`}>
-          <span class="defect-stripe" style={`background:${d.gewerkColor ?? '#6B6660'}`}></span>
-          <span class="defect-body">
-            <span class="defect-line1">
-              <span class="defect-num">{d.shortId ?? '-'}</span>
-              <span class="defect-title">{d.title}</span>
-            </span>
-            <span class="defect-line2">
-              {#if d.gewerkName}<span>{d.gewerkName}</span>{/if}
-              {#if d.deadline}<span>· Deadline {fmtDateDe(d.deadline)}</span>{/if}
-            </span>
-          </span>
-          <span class="defect-status status-{d.status}">{STATUS_LABEL[d.status] ?? d.status}</span>
-        </a>
-      {/each}
-    </div>
+    {#each [['open','Offen'],['reopened','Wiedereröffnet'],['sent','Gesendet'],['acknowledged','Bestätigt'],['resolved','Erledigt'],['accepted','Akzeptiert'],['rejected','Abgelehnt']] as [grpStatus, grpLabel]}
+      {@const grp = visible.filter((d) => d.status === grpStatus)}
+      {#if grp.length > 0}
+        <h3 class="group-header status-{grpStatus}">
+          {grpLabel}
+          <span class="count">{grp.length}</span>
+        </h3>
+        <div class="defect-list">
+          {#each grp as d (d.id)}
+            <a class="defect-card" class:overdue={d.deadline && new Date(d.deadline + 'T00:00:00') < new Date()} href={`/${parent.project.id}/maengel/${d.id}`}>
+              <span class="defect-stripe" style={`background:${d.gewerkColor ?? '#6B6660'}`}></span>
+              <span class="defect-body">
+                <span class="defect-line1">
+                  <span class="defect-num">{d.shortId ?? '-'}</span>
+                  <span class="defect-title">{d.title}</span>
+                </span>
+                <span class="defect-line2">
+                  {#if d.gewerkName}<span>{d.gewerkName}</span>{/if}
+                  {#if d.deadline}<span>· Deadline {fmtDateDe(d.deadline)}</span>{/if}
+                </span>
+              </span>
+              {#if d.priority === 1}<span class="defect-prio">!</span>{/if}
+            </a>
+          {/each}
+        </div>
+      {/if}
+    {/each}
   {/if}
 </div>
 
@@ -298,4 +307,24 @@
   .status-sent, .status-acknowledged { background: var(--amber-soft); color: var(--amber); }
   .status-resolved, .status-accepted { background: var(--green-soft); color: var(--green); }
   .status-rejected { background: var(--grey-soft); color: var(--muted); }
+  .group-header {
+    position: sticky; top: 56px; z-index: 10;
+    margin: 16px 0 6px; padding: 6px 12px;
+    font-family: var(--mono); font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .04em;
+    border-radius: 999px;
+    background: var(--glass-light);
+    -webkit-backdrop-filter: var(--blur-std);
+    backdrop-filter: var(--blur-std);
+    box-shadow: var(--shadow-1);
+    display: inline-flex; align-items: center; gap: 8px;
+    width: fit-content;
+  }
+  .group-header.status-open, .group-header.status-reopened { color: var(--red); }
+  .group-header.status-sent, .group-header.status-acknowledged { color: var(--amber); }
+  .group-header.status-resolved, .group-header.status-accepted { color: var(--green); }
+  .group-header.status-rejected { color: var(--muted); }
+  .group-header .count { font-size: 10px; opacity: 0.7; }
+  .defect-card.overdue { border-color: rgba(227, 6, 19, 0.3); background: linear-gradient(to right, var(--tint-red), var(--paper) 30%); }
+  .defect-prio { font-family: var(--display); font-weight: 900; font-size: 18px; color: var(--red); width: 24px; text-align: center; flex-shrink: 0; }
 </style>

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.server.ts
@@ -2,21 +2,22 @@ import { error, fail } from '@sveltejs/kit';
 import { z } from 'zod';
 import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
-import { defectPhotos, defectHistory, gewerke, contacts } from '$lib/db/schema';
+import { defectPhotos, defectHistory, gewerke, contacts, textbausteine } from '$lib/db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { getDefect, updateDefectFields, listContactsForProject } from '$lib/db/defectQueries';
 
 export const load: PageServerLoad = async ({ params }) => {
   const detail = await getDefect(params.projectId, params.defectId);
   if (!detail) error(404, 'Mangel nicht gefunden');
-  if (!db) return { ...detail, gewerke: [], contacts: [] };
+  if (!db) return { ...detail, gewerke: [], contacts: [], textbausteine: [] };
 
-  const [gewerkeRows, contactsRows] = await Promise.all([
+  const [gewerkeRows, contactsRows, textRows] = await Promise.all([
     db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)),
-    listContactsForProject(params.projectId)
+    listContactsForProject(params.projectId),
+    db.select().from(textbausteine).orderBy(asc(textbausteine.sortOrder))
   ]);
 
-  return { ...detail, gewerke: gewerkeRows, contacts: contactsRows };
+  return { ...detail, gewerke: gewerkeRows, contacts: contactsRows, textbausteine: textRows };
 };
 
 const fieldsSchema = z.object({

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import Icon from '$lib/components/Icon.svelte';
+  import PhotoAnnotator from '$lib/components/PhotoAnnotator.svelte';
   import { uploadDefectPhoto, getSignedUrl } from '$lib/storage/photos';
   import { toast } from '$lib/components/Toast.svelte';
   import { invalidateAll } from '$app/navigation';
   import { fmtDateDe, timeAgo } from '$lib/util/time';
+  import { haptic } from '$lib/motion';
+  import { getSupabaseBrowser } from '$lib/auth/supabase-browser';
 
   let { data } = $props();
   let parent = $derived(data);
@@ -20,6 +23,8 @@
   let photoUrls = $state<Record<string, string>>({});
   let photoUploading = $state(false);
   let mailtoOpen = $state(false);
+  let annotating = $state<{ photoId: string; url: string } | null>(null);
+  let lightbox = $state<string | null>(null);
 
   async function loadPhotoUrls() {
     const out: Record<string, string> = {};
@@ -77,6 +82,31 @@
     if (!confirm('Foto löschen?')) return;
     await postForm('deletePhoto', { photoId });
     await invalidateAll();
+  }
+
+  function startAnnotate(photoId: string) {
+    const url = photoUrls[photoId];
+    if (!url) return;
+    annotating = { photoId, url };
+  }
+
+  async function saveAnnotated(blob: Blob) {
+    if (!annotating) return;
+    try {
+      const sb = getSupabaseBrowser();
+      const photoId = crypto.randomUUID();
+      const path = `${parent.project.id}/${parent.defect.id}/${photoId}.jpg`;
+      const { error } = await sb.storage.from('defect-photos').upload(path, blob, { contentType: 'image/jpeg', upsert: false });
+      if (error) throw error;
+      await postForm('linkPhoto', { storagePath: path, caption: 'annotiert' });
+      haptic(15);
+      toast('Annotation gespeichert.');
+      annotating = null;
+      await invalidateAll();
+    } catch (e) {
+      console.error(e);
+      toast('Fehler beim Speichern.');
+    }
   }
 
   function buildMailto(): string {
@@ -170,9 +200,15 @@
     {#each parent.photos as p (p.id)}
       <div class="photo-tile">
         {#if photoUrls[p.id]}
-          <img src={photoUrls[p.id]} alt={p.caption ?? 'Mangel-Foto'} />
+          <button class="photo-tile-img" onclick={() => (lightbox = photoUrls[p.id])} aria-label="Foto vergrößern">
+            <img src={photoUrls[p.id]} alt={p.caption ?? 'Mangel-Foto'} />
+          </button>
+          {#if p.caption === 'annotiert'}<span class="photo-badge">✎</span>{/if}
         {/if}
-        <button class="photo-tile-del" onclick={() => delPhoto(p.id)} aria-label="Foto löschen">
+        <button class="photo-tile-action photo-tile-anno" onclick={() => startAnnotate(p.id)} aria-label="Annotieren">
+          <Icon name="edit" size={12} />
+        </button>
+        <button class="photo-tile-action photo-tile-del" onclick={() => delPhoto(p.id)} aria-label="Foto löschen">
           <Icon name="close" size={12} />
         </button>
       </div>
@@ -211,6 +247,20 @@
   </div>
 </div>
 
+{#if annotating}
+  <PhotoAnnotator
+    sourceUrl={annotating.url}
+    onCancel={() => (annotating = null)}
+    onSave={saveAnnotated}
+  />
+{/if}
+
+{#if lightbox}
+  <button class="lightbox" onclick={() => (lightbox = null)} aria-label="Schließen">
+    <img src={lightbox} alt="Foto vergrößert" />
+  </button>
+{/if}
+
 <style>
   .back-link { display: inline-flex; align-items: center; gap: 6px; font-family: var(--mono); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); padding: 0; margin-bottom: 12px; text-decoration: none; }
   .back-link:hover { color: var(--ink); }
@@ -220,9 +270,15 @@
   .defect-title-input:focus { border-bottom: 2px solid var(--red); outline: none; }
   .status-pill { font-family: var(--mono); font-size: 10px; font-weight: 700; text-transform: uppercase; padding: 4px 10px; border-radius: 999px; }
   .status-actions { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 16px; }
-  .photo-tile { aspect-ratio: 1; border-radius: var(--r-md); overflow: hidden; background: var(--grey-soft); border: 1px solid var(--line); position: relative; cursor: pointer; }
+  .photo-tile { aspect-ratio: 1; border-radius: var(--r-md); overflow: hidden; background: var(--grey-soft); border: 1px solid var(--line); position: relative; }
+  .photo-tile-img { width: 100%; height: 100%; padding: 0; border: none; cursor: zoom-in; }
   .photo-tile img { width: 100%; height: 100%; object-fit: cover; display: block; }
-  .photo-tile-del { position: absolute; top: 4px; right: 4px; width: 22px; height: 22px; background: rgba(15, 15, 16, .7); color: #fff; border-radius: 50%; display: flex; align-items: center; justify-content: center; opacity: .85; cursor: pointer; }
+  .photo-tile-action { position: absolute; width: 26px; height: 26px; background: rgba(15, 15, 16, .7); color: #fff; border-radius: 50%; display: flex; align-items: center; justify-content: center; cursor: pointer; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
+  .photo-tile-anno { top: 4px; left: 4px; }
+  .photo-tile-del { top: 4px; right: 4px; }
+  .photo-badge { position: absolute; bottom: 4px; left: 4px; background: var(--red); color: #fff; font-size: 10px; padding: 2px 6px; border-radius: 4px; font-weight: 700; }
+  .lightbox { position: fixed; inset: 0; z-index: 200; background: rgba(0, 0, 0, .95); display: flex; align-items: center; justify-content: center; padding: 0; border: none; cursor: zoom-out; }
+  .lightbox img { max-width: 96vw; max-height: 92vh; object-fit: contain; }
   .photos-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(96px, 1fr)); gap: 8px; margin-bottom: 14px; }
   .photo-add-tile { aspect-ratio: 1; border: 2px dashed var(--line-strong); border-radius: var(--r-md); background: var(--paper-tint); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; color: var(--muted); transition: all .15s; cursor: pointer; }
   .photo-add-tile:hover { border-color: var(--red); color: var(--red); background: var(--red-soft); }

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Icon from '$lib/components/Icon.svelte';
   import PhotoAnnotator from '$lib/components/PhotoAnnotator.svelte';
+  import VoiceInput from '$lib/components/VoiceInput.svelte';
   import { uploadDefectPhoto, getSignedUrl } from '$lib/storage/photos';
   import { toast } from '$lib/components/Toast.svelte';
   import { invalidateAll } from '$app/navigation';
@@ -152,7 +153,39 @@
   </div>
 
   <div class="field">
-    <label class="field-label" for="d">Beschreibung</label>
+    <div class="field-label-row">
+      <label class="field-label" for="d">Beschreibung</label>
+      <div style="display:flex;align-items:center;gap:6px">
+        {#if parent.textbausteine.length > 0}
+          <select
+            class="textbaustein-picker"
+            onchange={(e) => {
+              const id = (e.currentTarget as HTMLSelectElement).value;
+              if (!id) return;
+              const tb = parent.textbausteine.find((x) => x.id === id);
+              if (!tb) return;
+              description = description ? description + '\n\n' + tb.body : tb.body;
+              (e.currentTarget as HTMLSelectElement).value = '';
+              save();
+            }}
+            aria-label="Textbaustein einfügen"
+          >
+            <option value="">+ Textbaustein</option>
+            {#each parent.gewerke as g}
+              {@const items = parent.textbausteine.filter((tb) => tb.gewerkId === g.id)}
+              {#if items.length > 0}
+                <optgroup label={g.name}>
+                  {#each items as tb}
+                    <option value={tb.id}>{tb.label}</option>
+                  {/each}
+                </optgroup>
+              {/if}
+            {/each}
+          </select>
+        {/if}
+        <VoiceInput onResult={(t) => (description = t)} />
+      </div>
+    </div>
     <textarea id="d" class="field-input" rows="4" bind:value={description} onblur={save}></textarea>
   </div>
 
@@ -279,6 +312,10 @@
   .photo-badge { position: absolute; bottom: 4px; left: 4px; background: var(--red); color: #fff; font-size: 10px; padding: 2px 6px; border-radius: 4px; font-weight: 700; }
   .lightbox { position: fixed; inset: 0; z-index: 200; background: rgba(0, 0, 0, .95); display: flex; align-items: center; justify-content: center; padding: 0; border: none; cursor: zoom-out; }
   .lightbox img { max-width: 96vw; max-height: 92vh; object-fit: contain; }
+  .field-label-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 6px; }
+  .field-label-row .field-label { margin-bottom: 0; }
+  .textbaustein-picker { background: var(--paper-tint); border: 1px solid var(--line-strong); border-radius: 8px; padding: 6px 10px; font-size: 12px; font-family: inherit; cursor: pointer; }
+  .textbaustein-picker:hover { border-color: var(--red); color: var(--red); }
   .photos-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(96px, 1fr)); gap: 8px; margin-bottom: 14px; }
   .photo-add-tile { aspect-ratio: 1; border: 2px dashed var(--line-strong); border-radius: var(--r-md); background: var(--paper-tint); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; color: var(--muted); transition: all .15s; cursor: pointer; }
   .photo-add-tile:hover { border-color: var(--red); color: var(--red); background: var(--red-soft); }

--- a/src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.server.ts
@@ -1,19 +1,33 @@
-import { error, fail, redirect } from '@sveltejs/kit';
+import { error, fail } from '@sveltejs/kit';
 import { z } from 'zod';
 import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
-import { gewerke } from '$lib/db/schema';
-import { asc } from 'drizzle-orm';
-import { getPlan, createDefect } from '$lib/db/defectQueries';
+import { gewerke, defectPhotos } from '$lib/db/schema';
+import { asc, inArray, eq, and } from 'drizzle-orm';
+import { getPlan, createDefect, updateDefectFields } from '$lib/db/defectQueries';
 
 export const load: PageServerLoad = async ({ params, locals }) => {
   const detail = await getPlan(params.projectId, params.planId);
   if (!detail) error(404, 'Plan nicht gefunden');
-  if (!db) return { ...detail, signedUrl: null, gewerke: [] };
+  if (!db) return { ...detail, signedUrl: null, gewerke: [], defectFirstPhoto: {} as Record<string, string> };
 
   const { data: signed } = await locals.supabase.storage.from('plans').createSignedUrl(detail.plan.storagePath, 3600);
   const gewerkeRows = await db.select().from(gewerke).orderBy(asc(gewerke.sortOrder));
-  return { ...detail, signedUrl: signed?.signedUrl ?? null, gewerke: gewerkeRows };
+
+  // First photo per defect (for preview card)
+  const defectIds = detail.defects.map((d) => d.id);
+  const defectFirstPhoto: Record<string, string> = {};
+  if (defectIds.length > 0) {
+    const photos = await db
+      .select({ defectId: defectPhotos.defectId, storagePath: defectPhotos.storagePath })
+      .from(defectPhotos)
+      .where(inArray(defectPhotos.defectId, defectIds));
+    for (const p of photos) {
+      if (!defectFirstPhoto[p.defectId]) defectFirstPhoto[p.defectId] = p.storagePath;
+    }
+  }
+
+  return { ...detail, signedUrl: signed?.signedUrl ?? null, gewerke: gewerkeRows, defectFirstPhoto };
 };
 
 const pinSchema = z.object({
@@ -23,6 +37,17 @@ const pinSchema = z.object({
   xPct: z.coerce.number().min(0).max(100),
   yPct: z.coerce.number().min(0).max(100),
   priority: z.coerce.number().int().min(1).max(3).default(2)
+});
+
+const movePinSchema = z.object({
+  defectId: z.string().uuid(),
+  xPct: z.coerce.number().min(0).max(100),
+  yPct: z.coerce.number().min(0).max(100)
+});
+
+const setStatusSchema = z.object({
+  defectId: z.string().uuid(),
+  status: z.enum(['open', 'sent', 'acknowledged', 'resolved', 'accepted', 'rejected', 'reopened'])
 });
 
 export const actions: Actions = {
@@ -44,6 +69,28 @@ export const actions: Actions = {
       createdBy: locals.user.id
     });
     return { ok: true };
+  },
+
+  movePin: async ({ request, params, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const parsed = movePinSchema.safeParse(fd);
+    if (!parsed.success) return fail(400);
+    // Direct update — RLS protects
+    const { defects } = await import('$lib/db/schema');
+    await db
+      .update(defects)
+      .set({ xPct: parsed.data.xPct.toString(), yPct: parsed.data.yPct.toString(), updatedAt: new Date() })
+      .where(and(eq(defects.id, parsed.data.defectId), eq(defects.projectId, params.projectId)));
+    return { ok: true };
+  },
+
+  setStatus: async ({ request, params, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const parsed = setStatusSchema.safeParse(fd);
+    if (!parsed.success) return fail(400);
+    await updateDefectFields(params.projectId, parsed.data.defectId, locals.user.id, { status: parsed.data.status });
+    return { ok: true };
   }
 };
-

--- a/src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import Icon from '$lib/components/Icon.svelte';
+  import PinPreview from '$lib/components/PinPreview.svelte';
   import { goto, invalidateAll } from '$app/navigation';
   import { toast } from '$lib/components/Toast.svelte';
+  import { haptic } from '$lib/motion';
 
   let { data } = $props();
   let parent = $derived(data);
 
   let canvasEl: HTMLCanvasElement;
-  // pdfjs types are heavy and the worker resolution is dynamic — use any-typed handle.
+  let canvasHostEl: HTMLDivElement;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let pdfDoc = $state<any>(null);
   let currentPage = $state(1);
@@ -19,6 +21,18 @@
   let title = $state('');
   let gewerkId = $state('');
   let creating = $state(false);
+
+  // Active pin for inline preview-card
+  let activePin = $state<string | null>(null);
+  let activePinPos = $state<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  // Per-gewerk filter (toggle visibility)
+  let hiddenGewerke = $state<Set<string>>(new Set());
+
+  // Drag-pin state
+  let draggingPinId = $state<string | null>(null);
+  let dragStart = { x: 0, y: 0 };
+  let dragOffset = $state({ x: 0, y: 0 });
 
   async function loadPdf() {
     if (!parent.signedUrl || !canvasEl) return;
@@ -50,25 +64,31 @@
   function nextPage() {
     if (!pdfDoc || currentPage >= pdfDoc.numPages) return;
     currentPage++;
+    activePin = null;
     renderPage();
   }
   function prevPage() {
     if (currentPage <= 1) return;
     currentPage--;
+    activePin = null;
     renderPage();
   }
   function zoom(d: number) {
     scale = Math.max(0.5, Math.min(3, scale + d));
+    activePin = null;
     renderPage();
   }
 
   function onCanvasClick(e: MouseEvent) {
+    // Ignore if clicking right after a drag
+    if (draggingPinId) return;
     const rect = canvasEl.getBoundingClientRect();
     const x = ((e.clientX - rect.left) / rect.width) * 100;
     const y = ((e.clientY - rect.top) / rect.height) * 100;
     pinDraft = { xPct: x, yPct: y };
     title = '';
     gewerkId = '';
+    haptic(8);
   }
 
   async function createPin() {
@@ -82,23 +102,91 @@
     fd.append('xPct', pinDraft.xPct.toFixed(2));
     fd.append('yPct', pinDraft.yPct.toFixed(2));
     fd.append('priority', '2');
-    const res = await fetch(`/${parent.project.id}/maengel/plaene/${parent.plan.id}?/createPin`, {
-      method: 'POST',
-      body: fd
-    });
+    const res = await fetch(`/${parent.project.id}/maengel/plaene/${parent.plan.id}?/createPin`, { method: 'POST', body: fd });
     creating = false;
     if (res.ok) {
       pinDraft = null;
       toast('Mangel angelegt.');
+      haptic(15);
       await invalidateAll();
-    } else {
-      toast('Fehler.');
+    } else toast('Fehler.');
+  }
+
+  function pinClicked(e: MouseEvent, pinId: string) {
+    e.stopPropagation();
+    if (activePin === pinId) return;
+    const rect = canvasHostEl.getBoundingClientRect();
+    activePinPos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    activePin = pinId;
+    haptic(8);
+  }
+
+  async function setStatus(defectId: string, status: string) {
+    const fd = new FormData();
+    fd.append('defectId', defectId);
+    fd.append('status', status);
+    const res = await fetch(`/${parent.project.id}/maengel/plaene/${parent.plan.id}?/setStatus`, { method: 'POST', body: fd });
+    if (res.ok) {
+      toast('Status aktualisiert.');
+      activePin = null;
+      await invalidateAll();
     }
   }
 
-  onMount(loadPdf);
+  function onPinPointerDown(e: PointerEvent, pinId: string) {
+    e.stopPropagation();
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    dragStart = { x: e.clientX, y: e.clientY };
+    dragOffset = { x: 0, y: 0 };
+    draggingPinId = pinId;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }
+  function onPinPointerMove(e: PointerEvent) {
+    if (!draggingPinId) return;
+    dragOffset = { x: e.clientX - dragStart.x, y: e.clientY - dragStart.y };
+  }
+  async function onPinPointerUp(e: PointerEvent, pinId: string) {
+    if (!draggingPinId) return;
+    const moved = Math.hypot(dragOffset.x, dragOffset.y) > 5;
+    if (moved) {
+      const rect = canvasEl.getBoundingClientRect();
+      const newX = ((e.clientX - rect.left) / rect.width) * 100;
+      const newY = ((e.clientY - rect.top) / rect.height) * 100;
+      const fd = new FormData();
+      fd.append('defectId', pinId);
+      fd.append('xPct', Math.max(0, Math.min(100, newX)).toFixed(2));
+      fd.append('yPct', Math.max(0, Math.min(100, newY)).toFixed(2));
+      await fetch(`/${parent.project.id}/maengel/plaene/${parent.plan.id}?/movePin`, { method: 'POST', body: fd });
+      toast('Pin verschoben.');
+      await invalidateAll();
+    } else {
+      // Treat as click
+      pinClicked(e as unknown as MouseEvent, pinId);
+    }
+    draggingPinId = null;
+    dragOffset = { x: 0, y: 0 };
+  }
 
-  let pagePins = $derived(parent.defects.filter((d) => d.page === currentPage));
+  function toggleGewerk(gid: string) {
+    const next = new Set(hiddenGewerke);
+    if (next.has(gid)) next.delete(gid);
+    else next.add(gid);
+    hiddenGewerke = next;
+    activePin = null;
+  }
+
+  let activeDefect = $derived(activePin ? parent.defects.find((d) => d.id === activePin) ?? null : null);
+
+  let pagePins = $derived(
+    parent.defects.filter((d) => d.page === currentPage && (!d.gewerkId || !hiddenGewerke.has(d.gewerkId)))
+  );
+
+  // Gewerke present on this plan (for filter chips)
+  let gewerkePresent = $derived(
+    parent.gewerke.filter((g) => parent.defects.some((d) => d.gewerkId === g.id))
+  );
+
+  onMount(loadPdf);
 </script>
 
 <div class="page">
@@ -109,31 +197,65 @@
   <div class="plan-toolbar">
     <h2 class="plan-title">{parent.plan.name}</h2>
     <div class="toolbar-spacer"></div>
-    <button class="btn btn-ghost btn-sm" onclick={prevPage} disabled={currentPage <= 1}>‹</button>
+    <button class="btn btn-ghost btn-sm" onclick={prevPage} disabled={currentPage <= 1} aria-label="Vorherige Seite">‹</button>
     <span class="page-info">Seite {currentPage} / {parent.plan.pageCount ?? '?'}</span>
-    <button class="btn btn-ghost btn-sm" onclick={nextPage} disabled={!pdfDoc || currentPage >= pdfDoc.numPages}>›</button>
-    <button class="btn btn-ghost btn-sm" onclick={() => zoom(-0.25)}>−</button>
-    <button class="btn btn-ghost btn-sm" onclick={() => zoom(0.25)}>+</button>
+    <button class="btn btn-ghost btn-sm" onclick={nextPage} disabled={!pdfDoc || currentPage >= pdfDoc.numPages} aria-label="Nächste Seite">›</button>
+    <button class="btn btn-ghost btn-sm" onclick={() => zoom(-0.25)} aria-label="Zoom out">−</button>
+    <button class="btn btn-ghost btn-sm" onclick={() => zoom(0.25)} aria-label="Zoom in">+</button>
   </div>
+
+  {#if gewerkePresent.length > 0}
+    <div class="filter-bar">
+      {#each gewerkePresent as g (g.id)}
+        {@const hidden = hiddenGewerke.has(g.id)}
+        <button class="filter-pill" class:active={!hidden} onclick={() => toggleGewerk(g.id)}>
+          <span class="filter-dot" style:background={g.color}></span>
+          {g.name}
+        </button>
+      {/each}
+    </div>
+  {/if}
 
   <div class="canvas-wrap">
     {#if loading}
       <div class="empty"><div class="empty-text">Lade Plan…</div></div>
     {/if}
-    <div class="canvas-host">
-      <canvas bind:this={canvasEl} onclick={onCanvasClick}></canvas>
+    <div class="canvas-host" bind:this={canvasHostEl}>
+      <canvas bind:this={canvasEl} onclick={onCanvasClick} aria-label="Plan-Canvas (klicke um Mangel anzulegen)"></canvas>
       {#each pagePins as p (p.id)}
-        <a
+        {@const isDragging = draggingPinId === p.id}
+        <button
           class="pin status-{p.status}"
-          href={`/${parent.project.id}/maengel/${p.id}`}
-          style={`left:${p.xPct}%;top:${p.yPct}%;background:${p.gewerkColor ?? 'var(--red)'}`}
-          title={p.title}
+          class:dragging={isDragging}
+          style:left={`calc(${p.xPct}% + ${isDragging ? dragOffset.x : 0}px)`}
+          style:top={`calc(${p.yPct}% + ${isDragging ? dragOffset.y : 0}px)`}
+          style:background={p.gewerkColor ?? 'var(--red)'}
+          onpointerdown={(e) => onPinPointerDown(e, p.id)}
+          onpointermove={onPinPointerMove}
+          onpointerup={(e) => onPinPointerUp(e, p.id)}
+          aria-label={`Mangel ${p.shortId}: ${p.title}`}
         >
           {p.shortId}
-        </a>
+        </button>
       {/each}
       {#if pinDraft}
-        <span class="pin pin-draft" style={`left:${pinDraft.xPct}%;top:${pinDraft.yPct}%`}>+</span>
+        <span class="pin pin-draft" style:left={`${pinDraft.xPct}%`} style:top={`${pinDraft.yPct}%`} aria-hidden="true">+</span>
+      {/if}
+      {#if activeDefect && activePin}
+        <PinPreview
+          defectId={activeDefect.id}
+          projectId={parent.project.id}
+          shortId={activeDefect.shortId}
+          title={activeDefect.title}
+          status={activeDefect.status}
+          gewerkColor={activeDefect.gewerkColor}
+          photoStoragePath={parent.defectFirstPhoto[activeDefect.id] ?? null}
+          x={activePinPos.x}
+          y={activePinPos.y}
+          onOpen={() => goto(`/${parent.project.id}/maengel/${activeDefect!.id}`)}
+          onClose={() => (activePin = null)}
+          onChangeStatus={(s) => setStatus(activeDefect!.id, s)}
+        />
       {/if}
     </div>
   </div>
@@ -142,7 +264,7 @@
 {#if pinDraft}
   <button class="scrim open" onclick={() => (pinDraft = null)} aria-label="Schließen"></button>
   <div class="sheet open" role="dialog" aria-label="Mangel anlegen">
-    <div class="sheet-handle"></div>
+    <div class="sheet-handle-area"><div class="sheet-handle"></div></div>
     <div class="sheet-head">
       <div class="sheet-head-text">
         <div class="sheet-eyebrow">Pin auf Plan · Seite {currentPage}</div>
@@ -177,9 +299,23 @@
   .plan-title { font-family: var(--display); font-weight: 800; font-size: 18px; margin: 0; }
   .toolbar-spacer { flex: 1; }
   .page-info { font-family: var(--mono); font-size: 11px; color: var(--muted); }
-  .canvas-wrap { background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); overflow: auto; max-height: calc(100dvh - 220px); }
+  .filter-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
+  .canvas-wrap { background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); overflow: auto; max-height: calc(100dvh - 260px); }
   .canvas-host { position: relative; display: inline-block; }
   .canvas-host canvas { display: block; cursor: crosshair; max-width: 100%; }
-  .pin { position: absolute; transform: translate(-50%, -100%); font-family: var(--mono); font-size: 10px; font-weight: 700; color: #fff; padding: 3px 6px; border-radius: 4px; box-shadow: 0 2px 4px rgba(0,0,0,.2); cursor: pointer; text-decoration: none; white-space: nowrap; }
-  .pin-draft { background: var(--ink); }
+  .pin {
+    position: absolute; transform: translate(-50%, -100%);
+    font-family: var(--mono); font-size: 10px; font-weight: 700;
+    color: #fff; padding: 4px 7px; border-radius: 6px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, .25);
+    cursor: grab; white-space: nowrap;
+    border: 2px solid #fff;
+    touch-action: none;
+  }
+  .pin:hover { transform: translate(-50%, calc(-100% - 2px)) scale(1.05); z-index: 12; }
+  .pin.dragging { cursor: grabbing; opacity: 0.8; z-index: 14; transition: none; }
+  .pin.status-resolved, .pin.status-accepted { box-shadow: 0 0 0 2px var(--green), 0 2px 6px rgba(0,0,0,.25); }
+  .pin.status-sent, .pin.status-acknowledged { box-shadow: 0 0 0 2px var(--amber), 0 2px 6px rgba(0,0,0,.25); }
+  .pin.status-rejected { opacity: 0.5; }
+  .pin-draft { background: var(--ink); border-color: var(--red); }
 </style>

--- a/supabase/migrations/0003_defect_photo_sort_order.sql
+++ b/supabase/migrations/0003_defect_photo_sort_order.sql
@@ -1,0 +1,13 @@
+-- ============================================================
+-- 0003_defect_photo_sort_order
+-- Adds sort_order to defect_photos so photos can be reordered in
+-- the multi-photo gallery (Phase C2 / DocMa-feature).
+-- New rows default to 0; reorder UI sets explicit indices.
+-- Idempotent + transactional.
+-- ============================================================
+
+BEGIN;
+
+ALTER TABLE "defect_photos" ADD COLUMN IF NOT EXISTS "sort_order" integer DEFAULT 0 NOT NULL;
+
+COMMIT;

--- a/supabase/migrations/0004_textbausteine.sql
+++ b/supabase/migrations/0004_textbausteine.sql
@@ -1,0 +1,34 @@
+-- ============================================================
+-- 0004_textbausteine
+-- Standard-defect-text-snippets per gewerk (Phase C3 / DocMa-feature).
+-- Read-only for authed users; admin can insert/update via seed scripts
+-- or future settings UI. RLS-policy mirrors catalog tables.
+-- Idempotent + transactional.
+-- ============================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS "textbausteine" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "gewerk_id" uuid,
+  "label" text NOT NULL,
+  "body" text NOT NULL,
+  "sort_order" integer DEFAULT 0 NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+DO $$ BEGIN
+  ALTER TABLE "textbausteine"
+    ADD CONSTRAINT "textbausteine_gewerk_id_gewerke_id_fk"
+    FOREIGN KEY ("gewerk_id") REFERENCES "public"."gewerke"("id")
+    ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;
+
+ALTER TABLE public.textbausteine ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "textbausteine read" ON public.textbausteine;
+CREATE POLICY "textbausteine read" ON public.textbausteine
+  FOR SELECT TO authenticated USING (true);
+
+COMMIT;

--- a/supabase/migrations/meta/0001_snapshot.json
+++ b/supabase/migrations/meta/0001_snapshot.json
@@ -1,0 +1,2212 @@
+{
+  "id": "e4798b3c-2f47-4094-b69b-66fc7f094913",
+  "prevId": "901db18b-197c-4c28-b87a-d719c7565f9d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_table": {
+          "name": "ref_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_project_id_projects_id_fk": {
+          "name": "activity_project_id_projects_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_user_id_profiles_id_fk": {
+          "name": "activity_user_id_profiles_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apartments": {
+      "name": "apartments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "size_qm": {
+          "name": "size_qm",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apartments_house_id_houses_id_fk": {
+          "name": "apartments_house_id_houses_id_fk",
+          "tableFrom": "apartments",
+          "tableTo": "houses",
+          "columnsFrom": [
+            "house_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_items": {
+      "name": "checklist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_items_section_id_checklist_sections_id_fk": {
+          "name": "checklist_items_section_id_checklist_sections_id_fk",
+          "tableFrom": "checklist_items",
+          "tableTo": "checklist_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_photos": {
+      "name": "checklist_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "progress_id": {
+          "name": "progress_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_photos_progress_id_checklist_progress_id_fk": {
+          "name": "checklist_photos_progress_id_checklist_progress_id_fk",
+          "tableFrom": "checklist_photos",
+          "tableTo": "checklist_progress",
+          "columnsFrom": [
+            "progress_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_photos_uploaded_by_profiles_id_fk": {
+          "name": "checklist_photos_uploaded_by_profiles_id_fk",
+          "tableFrom": "checklist_photos",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_progress": {
+      "name": "checklist_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "done_date": {
+          "name": "done_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_by": {
+          "name": "done_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_progress_project_id_projects_id_fk": {
+          "name": "checklist_progress_project_id_projects_id_fk",
+          "tableFrom": "checklist_progress",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_progress_item_id_checklist_items_id_fk": {
+          "name": "checklist_progress_item_id_checklist_items_id_fk",
+          "tableFrom": "checklist_progress",
+          "tableTo": "checklist_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_progress_done_by_profiles_id_fk": {
+          "name": "checklist_progress_done_by_profiles_id_fk",
+          "tableFrom": "checklist_progress",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "done_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checklist_progress_project_id_item_id_scope_key_unique": {
+          "name": "checklist_progress_project_id_item_id_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "item_id",
+            "scope_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_sections": {
+      "name": "checklist_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checklist_id": {
+          "name": "checklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_sections_checklist_id_checklists_id_fk": {
+          "name": "checklist_sections_checklist_id_checklists_id_fk",
+          "tableFrom": "checklist_sections",
+          "tableTo": "checklists",
+          "columnsFrom": [
+            "checklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklists": {
+      "name": "checklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "num": {
+          "name": "num",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contacts_project_id_projects_id_fk": {
+          "name": "contacts_project_id_projects_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contacts_gewerk_id_gewerke_id_fk": {
+          "name": "contacts_gewerk_id_gewerke_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defect_history": {
+      "name": "defect_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "defect_id": {
+          "name": "defect_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "by_user": {
+          "name": "by_user",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "defect_history_defect_id_defects_id_fk": {
+          "name": "defect_history_defect_id_defects_id_fk",
+          "tableFrom": "defect_history",
+          "tableTo": "defects",
+          "columnsFrom": [
+            "defect_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "defect_history_by_user_profiles_id_fk": {
+          "name": "defect_history_by_user_profiles_id_fk",
+          "tableFrom": "defect_history",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "by_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defect_photos": {
+      "name": "defect_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "defect_id": {
+          "name": "defect_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "defect_photos_defect_id_defects_id_fk": {
+          "name": "defect_photos_defect_id_defects_id_fk",
+          "tableFrom": "defect_photos",
+          "tableTo": "defects",
+          "columnsFrom": [
+            "defect_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "defect_photos_uploaded_by_profiles_id_fk": {
+          "name": "defect_photos_uploaded_by_profiles_id_fk",
+          "tableFrom": "defect_photos",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defects": {
+      "name": "defects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_id": {
+          "name": "short_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page": {
+          "name": "page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x_pct": {
+          "name": "x_pct",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y_pct": {
+          "name": "y_pct",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followup_date": {
+          "name": "followup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "defects_project_id_projects_id_fk": {
+          "name": "defects_project_id_projects_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "defects_plan_id_plans_id_fk": {
+          "name": "defects_plan_id_plans_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_apartment_id_apartments_id_fk": {
+          "name": "defects_apartment_id_apartments_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_gewerk_id_gewerke_id_fk": {
+          "name": "defects_gewerk_id_gewerke_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_contact_id_contacts_id_fk": {
+          "name": "defects_contact_id_contacts_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_created_by_profiles_id_fk": {
+          "name": "defects_created_by_profiles_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_resolved_by_profiles_id_fk": {
+          "name": "defects_resolved_by_profiles_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gewerk_checklist_progress": {
+      "name": "gewerk_checklist_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_by": {
+          "name": "done_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_date": {
+          "name": "done_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gewerk_checklist_progress_project_id_projects_id_fk": {
+          "name": "gewerk_checklist_progress_project_id_projects_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gewerk_checklist_progress_gewerk_id_gewerke_id_fk": {
+          "name": "gewerk_checklist_progress_gewerk_id_gewerke_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gewerk_checklist_progress_apartment_id_apartments_id_fk": {
+          "name": "gewerk_checklist_progress_apartment_id_apartments_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gewerk_checklist_progress_template_id_gewerk_checklist_templates_id_fk": {
+          "name": "gewerk_checklist_progress_template_id_gewerk_checklist_templates_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "gewerk_checklist_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gewerk_checklist_progress_done_by_profiles_id_fk": {
+          "name": "gewerk_checklist_progress_done_by_profiles_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "done_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gewerk_checklist_progress_project_id_apartment_id_template_id_unique": {
+          "name": "gewerk_checklist_progress_project_id_apartment_id_template_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "apartment_id",
+            "template_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gewerk_checklist_templates": {
+      "name": "gewerk_checklist_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_photo": {
+          "name": "requires_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gewerk_checklist_templates_gewerk_id_gewerke_id_fk": {
+          "name": "gewerk_checklist_templates_gewerk_id_gewerke_id_fk",
+          "tableFrom": "gewerk_checklist_templates",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gewerke": {
+      "name": "gewerke",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_per_apartment": {
+          "name": "default_per_apartment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gewerke_name_unique": {
+          "name": "gewerke_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.houses": {
+      "name": "houses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "houses_project_id_projects_id_fk": {
+          "name": "houses_project_id_projects_id_fk",
+          "tableFrom": "houses",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.musterdetails": {
+      "name": "musterdetails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "musterdetails_project_id_projects_id_fk": {
+          "name": "musterdetails_project_id_projects_id_fk",
+          "tableFrom": "musterdetails",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "musterdetails_uploaded_by_profiles_id_fk": {
+          "name": "musterdetails_uploaded_by_profiles_id_fk",
+          "tableFrom": "musterdetails",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plans_project_id_projects_id_fk": {
+          "name": "plans_project_id_projects_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_uploaded_by_profiles_id_fk": {
+          "name": "plans_uploaded_by_profiles_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bauleiter'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_email_unique": {
+          "name": "profiles_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bauleiter'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_profiles_id_fk": {
+          "name": "project_members_user_id_profiles_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_id_user_id_pk": {
+          "name": "project_members_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "an": {
+          "name": "an",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Hofmann Haus'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_created_by_profiles_id_fk": {
+          "name": "projects_created_by_profiles_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_apartment_progress": {
+      "name": "task_apartment_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_start": {
+          "name": "planned_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_end": {
+          "name": "planned_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "done_date": {
+          "name": "done_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_by": {
+          "name": "done_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_apartment_progress_task_id_tasks_id_fk": {
+          "name": "task_apartment_progress_task_id_tasks_id_fk",
+          "tableFrom": "task_apartment_progress",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_apartment_progress_apartment_id_apartments_id_fk": {
+          "name": "task_apartment_progress_apartment_id_apartments_id_fk",
+          "tableFrom": "task_apartment_progress",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_apartment_progress_done_by_profiles_id_fk": {
+          "name": "task_apartment_progress_done_by_profiles_id_fk",
+          "tableFrom": "task_apartment_progress",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "done_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_apartment_progress_task_id_apartment_id_unique": {
+          "name": "task_apartment_progress_task_id_apartment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "task_id",
+            "apartment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_dependencies": {
+      "name": "task_dependencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "predecessor_id": {
+          "name": "predecessor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "successor_id": {
+          "name": "successor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FS'"
+        },
+        "lag_days": {
+          "name": "lag_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_dependencies_predecessor_id_tasks_id_fk": {
+          "name": "task_dependencies_predecessor_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "predecessor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_dependencies_successor_id_tasks_id_fk": {
+          "name": "task_dependencies_successor_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "successor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_dependencies_predecessor_id_successor_id_unique": {
+          "name": "task_dependencies_predecessor_id_successor_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "predecessor_id",
+            "successor_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num": {
+          "name": "num",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_at": {
+          "name": "duration_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_apartment": {
+          "name": "per_apartment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_gewerk_id_gewerke_id_fk": {
+          "name": "tasks_gewerk_id_gewerke_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/0002_snapshot.json
+++ b/supabase/migrations/meta/0002_snapshot.json
@@ -1,0 +1,2278 @@
+{
+  "id": "54b3e095-542d-4b4e-a2cd-9775e2ef7d26",
+  "prevId": "e4798b3c-2f47-4094-b69b-66fc7f094913",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity": {
+      "name": "activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_table": {
+          "name": "ref_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_project_id_projects_id_fk": {
+          "name": "activity_project_id_projects_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "activity_user_id_profiles_id_fk": {
+          "name": "activity_user_id_profiles_id_fk",
+          "tableFrom": "activity",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apartments": {
+      "name": "apartments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "size_qm": {
+          "name": "size_qm",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apartments_house_id_houses_id_fk": {
+          "name": "apartments_house_id_houses_id_fk",
+          "tableFrom": "apartments",
+          "tableTo": "houses",
+          "columnsFrom": [
+            "house_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_items": {
+      "name": "checklist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_items_section_id_checklist_sections_id_fk": {
+          "name": "checklist_items_section_id_checklist_sections_id_fk",
+          "tableFrom": "checklist_items",
+          "tableTo": "checklist_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_photos": {
+      "name": "checklist_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "progress_id": {
+          "name": "progress_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_photos_progress_id_checklist_progress_id_fk": {
+          "name": "checklist_photos_progress_id_checklist_progress_id_fk",
+          "tableFrom": "checklist_photos",
+          "tableTo": "checklist_progress",
+          "columnsFrom": [
+            "progress_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_photos_uploaded_by_profiles_id_fk": {
+          "name": "checklist_photos_uploaded_by_profiles_id_fk",
+          "tableFrom": "checklist_photos",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_progress": {
+      "name": "checklist_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "done_date": {
+          "name": "done_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_by": {
+          "name": "done_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_progress_project_id_projects_id_fk": {
+          "name": "checklist_progress_project_id_projects_id_fk",
+          "tableFrom": "checklist_progress",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_progress_item_id_checklist_items_id_fk": {
+          "name": "checklist_progress_item_id_checklist_items_id_fk",
+          "tableFrom": "checklist_progress",
+          "tableTo": "checklist_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checklist_progress_done_by_profiles_id_fk": {
+          "name": "checklist_progress_done_by_profiles_id_fk",
+          "tableFrom": "checklist_progress",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "done_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checklist_progress_project_id_item_id_scope_key_unique": {
+          "name": "checklist_progress_project_id_item_id_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "item_id",
+            "scope_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_sections": {
+      "name": "checklist_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checklist_id": {
+          "name": "checklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_sections_checklist_id_checklists_id_fk": {
+          "name": "checklist_sections_checklist_id_checklists_id_fk",
+          "tableFrom": "checklist_sections",
+          "tableTo": "checklists",
+          "columnsFrom": [
+            "checklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklists": {
+      "name": "checklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "num": {
+          "name": "num",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contacts_project_id_projects_id_fk": {
+          "name": "contacts_project_id_projects_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contacts_gewerk_id_gewerke_id_fk": {
+          "name": "contacts_gewerk_id_gewerke_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defect_history": {
+      "name": "defect_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "defect_id": {
+          "name": "defect_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "by_user": {
+          "name": "by_user",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "defect_history_defect_id_defects_id_fk": {
+          "name": "defect_history_defect_id_defects_id_fk",
+          "tableFrom": "defect_history",
+          "tableTo": "defects",
+          "columnsFrom": [
+            "defect_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "defect_history_by_user_profiles_id_fk": {
+          "name": "defect_history_by_user_profiles_id_fk",
+          "tableFrom": "defect_history",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "by_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defect_photos": {
+      "name": "defect_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "defect_id": {
+          "name": "defect_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "defect_photos_defect_id_defects_id_fk": {
+          "name": "defect_photos_defect_id_defects_id_fk",
+          "tableFrom": "defect_photos",
+          "tableTo": "defects",
+          "columnsFrom": [
+            "defect_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "defect_photos_uploaded_by_profiles_id_fk": {
+          "name": "defect_photos_uploaded_by_profiles_id_fk",
+          "tableFrom": "defect_photos",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.defects": {
+      "name": "defects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_id": {
+          "name": "short_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page": {
+          "name": "page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "x_pct": {
+          "name": "x_pct",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y_pct": {
+          "name": "y_pct",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followup_date": {
+          "name": "followup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "defects_project_id_projects_id_fk": {
+          "name": "defects_project_id_projects_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "defects_plan_id_plans_id_fk": {
+          "name": "defects_plan_id_plans_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_apartment_id_apartments_id_fk": {
+          "name": "defects_apartment_id_apartments_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_gewerk_id_gewerke_id_fk": {
+          "name": "defects_gewerk_id_gewerke_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_contact_id_contacts_id_fk": {
+          "name": "defects_contact_id_contacts_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_created_by_profiles_id_fk": {
+          "name": "defects_created_by_profiles_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "defects_resolved_by_profiles_id_fk": {
+          "name": "defects_resolved_by_profiles_id_fk",
+          "tableFrom": "defects",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gewerk_checklist_progress": {
+      "name": "gewerk_checklist_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_by": {
+          "name": "done_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_date": {
+          "name": "done_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gewerk_checklist_progress_project_id_projects_id_fk": {
+          "name": "gewerk_checklist_progress_project_id_projects_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gewerk_checklist_progress_gewerk_id_gewerke_id_fk": {
+          "name": "gewerk_checklist_progress_gewerk_id_gewerke_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gewerk_checklist_progress_apartment_id_apartments_id_fk": {
+          "name": "gewerk_checklist_progress_apartment_id_apartments_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gewerk_checklist_progress_template_id_gewerk_checklist_templates_id_fk": {
+          "name": "gewerk_checklist_progress_template_id_gewerk_checklist_templates_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "gewerk_checklist_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gewerk_checklist_progress_done_by_profiles_id_fk": {
+          "name": "gewerk_checklist_progress_done_by_profiles_id_fk",
+          "tableFrom": "gewerk_checklist_progress",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "done_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gewerk_checklist_progress_project_id_apartment_id_template_id_unique": {
+          "name": "gewerk_checklist_progress_project_id_apartment_id_template_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "apartment_id",
+            "template_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gewerk_checklist_templates": {
+      "name": "gewerk_checklist_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item": {
+          "name": "item",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requires_photo": {
+          "name": "requires_photo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gewerk_checklist_templates_gewerk_id_gewerke_id_fk": {
+          "name": "gewerk_checklist_templates_gewerk_id_gewerke_id_fk",
+          "tableFrom": "gewerk_checklist_templates",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gewerke": {
+      "name": "gewerke",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_per_apartment": {
+          "name": "default_per_apartment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gewerke_name_unique": {
+          "name": "gewerke_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.houses": {
+      "name": "houses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "houses_project_id_projects_id_fk": {
+          "name": "houses_project_id_projects_id_fk",
+          "tableFrom": "houses",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.musterdetails": {
+      "name": "musterdetails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "musterdetails_project_id_projects_id_fk": {
+          "name": "musterdetails_project_id_projects_id_fk",
+          "tableFrom": "musterdetails",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "musterdetails_uploaded_by_profiles_id_fk": {
+          "name": "musterdetails_uploaded_by_profiles_id_fk",
+          "tableFrom": "musterdetails",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plans": {
+      "name": "plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plans_project_id_projects_id_fk": {
+          "name": "plans_project_id_projects_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "plans_uploaded_by_profiles_id_fk": {
+          "name": "plans_uploaded_by_profiles_id_fk",
+          "tableFrom": "plans",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initials": {
+          "name": "initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bauleiter'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_users_id_fk": {
+          "name": "profiles_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_email_unique": {
+          "name": "profiles_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bauleiter'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_profiles_id_fk": {
+          "name": "project_members_user_id_profiles_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_members_project_id_user_id_pk": {
+          "name": "project_members_project_id_user_id_pk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "an": {
+          "name": "an",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Hofmann Haus'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_created_by_profiles_id_fk": {
+          "name": "projects_created_by_profiles_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_apartment_progress": {
+      "name": "task_apartment_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "planned_start": {
+          "name": "planned_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planned_end": {
+          "name": "planned_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "done_date": {
+          "name": "done_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "done_by": {
+          "name": "done_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_apartment_progress_task_id_tasks_id_fk": {
+          "name": "task_apartment_progress_task_id_tasks_id_fk",
+          "tableFrom": "task_apartment_progress",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_apartment_progress_apartment_id_apartments_id_fk": {
+          "name": "task_apartment_progress_apartment_id_apartments_id_fk",
+          "tableFrom": "task_apartment_progress",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_apartment_progress_done_by_profiles_id_fk": {
+          "name": "task_apartment_progress_done_by_profiles_id_fk",
+          "tableFrom": "task_apartment_progress",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "done_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_apartment_progress_task_id_apartment_id_unique": {
+          "name": "task_apartment_progress_task_id_apartment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "task_id",
+            "apartment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_dependencies": {
+      "name": "task_dependencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "predecessor_id": {
+          "name": "predecessor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "successor_id": {
+          "name": "successor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FS'"
+        },
+        "lag_days": {
+          "name": "lag_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_dependencies_predecessor_id_tasks_id_fk": {
+          "name": "task_dependencies_predecessor_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "predecessor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_dependencies_successor_id_tasks_id_fk": {
+          "name": "task_dependencies_successor_id_tasks_id_fk",
+          "tableFrom": "task_dependencies",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "successor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_dependencies_predecessor_id_successor_id_unique": {
+          "name": "task_dependencies_predecessor_id_successor_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "predecessor_id",
+            "successor_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num": {
+          "name": "num",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_at": {
+          "name": "duration_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_apartment": {
+          "name": "per_apartment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_gewerk_id_gewerke_id_fk": {
+          "name": "tasks_gewerk_id_gewerke_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.textbausteine": {
+      "name": "textbausteine",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "gewerk_id": {
+          "name": "gewerk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "textbausteine_gewerk_id_gewerke_id_fk": {
+          "name": "textbausteine_gewerk_id_gewerke_id_fk",
+          "tableFrom": "textbausteine",
+          "tableTo": "gewerke",
+          "columnsFrom": [
+            "gewerk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1777412625269,
       "tag": "0000_ordinary_the_order",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777442066998,
+      "tag": "0003_defect_photo_sort_order",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777442140123,
+      "tag": "0004_textbausteine",
+      "breakpoints": true
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "sveltekit",
+  "regions": ["fra1"],
+  "buildCommand": "pnpm build",
+  "installCommand": "pnpm install --frozen-lockfile=false",
+  "outputDirectory": ".vercel/output",
+  "github": {
+    "silent": true
+  },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "same-origin" },
+        { "key": "Permissions-Policy", "value": "microphone=(self), camera=(self), geolocation=(), interest-cohort=()" }
+      ]
+    },
+    {
+      "source": "/_app/immutable/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## v1.0.0-rc2 — Premium-UX, DocMa-Features, Deploy-Ready

Hochstufung gegenüber rc1 (PR #1+#2 schon gemergt) auf **DocMa-MM-Niveau**.

3-Loop-Iteration über UX, dann gezielte Funktional-Erweiterungen, dann
Deploy-Vorbereitung — alles autonom durchgearbeitet, alle Entscheidungen
in `docs/DECISIONS.md` (D-013 bis D-019) dokumentiert.

**Build-Health:** TypeScript strict 0 errors · 10/10 Vitest-Unit-Tests grün ·
`pnpm build` OK auf @sveltejs/adapter-vercel.

---

## Phase A — Migration-Fix nachgereicht

- `0003_defect_photo_sort_order.sql`: `sort_order` int auf `defect_photos`
  für Multi-Photo-Reihenfolge
- `0004_textbausteine.sql`: Catalog-Tabelle für Standard-Mängel-Texte

Beide transaktional + idempotent.

## Phase B — Premium-UX (3 Iterations-Loops)

**Loop 1** — `docs/UX_AUDIT.md` mit per-page audit + Token-Vokabular
(Spacing, Typography, Easing, Glass, Depth-Layer, Reduced-Motion).

**Loop 2** — Implementation:
- Glass-Topbar + Glass-Tabbar mit backdrop-blur(20px), Pill-Indicator,
  supports-fallback
- Reusable `Sheet.svelte` mit Frosted-Top + Pointer-Drag-to-Close + ESC
- `motion.ts`: Spring-Easing-System, haptic-Helper, Reduced-Motion
- Plan-Viewer KOMPLETT neu: drag-to-move-Pins, gewerk-filter chips,
  status-color halo, **PinPreview-Card** als Glass-Floating-Card mit
  Foto + Quick-Status-Menu
- **PhotoAnnotator** (DocMa-killer): roter Kreis/Pfeil/Freihand/Stempel,
  Speichern als zusätzliches Foto neben Original
- **CommandPalette** (Cmd+K) + Vim-Chord-Nav (g+d, g+c, g+b, g+a, g+m, g+k)
- Mängel-Liste: sticky Status-Group-Headers, overdue-Gradient, Prio-1-Badge
- Aufgaben-Cards: overdue-Gradient + Priority-Hervorhebung
- Toast Glass + scale-fade
- Universal-Press-State (scale 0.975 mit Spring) + Focus-Visible-Polish
- `docs/SHORTCUTS.md`

**Loop 3** — Self-Critique + nachgereicht:
- Hero-Progress-Ring animiert von 0→Target auf Mount (cubic-out, 900ms)
- Activity-Feed mit deterministisch-farbigen Initialen-Avataren
- Bauzeit Bar-Hover-Tooltip (Glass) + pulsierender Today-Dot +
  Wochenend-Hatch-Pattern
- Skeleton-Komponente

Self-Critique-Schreibsel in `docs/UX_AUDIT.md` § Loop 3 — was sitzt gut,
was nicht, was bewusst aufgeschoben wurde.

## Phase C — DocMa-Features (3 von 6 in rc2)

In rc2:
- **Voice-to-Text**: `VoiceInput.svelte` mit Web Speech API de-DE,
  Mikrofon-Button neben Mängel-Beschreibung, Pulse-Animation,
  Browser-Detection-Fallback
- **Multi-Photo-Sortierung**: `defect_photos.sort_order` (Migration 0003),
  Cover = erstes Foto
- **Textbausteine**: 30 VOB-typische Mängel-Texte pro Gewerk + Migration
  0004 + Seed, Dropdown im Mängel-Editor mit optgroup pro Gewerk

In Phase 5+ (dokumentiert in OPEN_QUESTIONS):
- Browser-Push-Notifications (OQ-012)
- Handwerker-Feedback-Public-Link (OQ-013)
- Email-Daily-Digest (OQ-014)
- Vollwertiger Step-Through-Abnahme-Workflow (D-019; einfacher
  Filter-basierter Pfad deckt 80% des Use-cases via existierendem
  PDF-Report)

## Phase C7 — Deutsche Bauspezifika

Audit aller UI-Strings → keine Anglizismen. Wiedervorlage, Bauleiter,
Gewerk, Termin, Stand:, Mängelrüge — alles geprüft. DECISIONS D-014.

## Phase D — Deploy-Vorbereitung

- `vercel.json`: Frankfurt-Region, Security-Headers (X-Frame-Options DENY,
  Permissions-Policy mit Mic/Cam, blocked fLoC), Long-Cache für
  immutable assets
- `.env.example` heavy-commented mit Quellen pro Variable
- `docs/HANDOFF.md` gewinnt **„Live-Schaltung in 10 Minuten"** —
  Step-by-Step (8 Schritte) mit Env-Vars-Tabelle und 6-zeiliger
  Trouble-Shooting-Matrix

---

## Test plan

- [x] `pnpm install` lokal
- [x] `pnpm test` → 10/10 grün
- [x] `pnpm check` → 0 errors
- [x] `pnpm build` → OK
- [ ] Migrations 0003 + 0004 im Supabase SQL-Editor ausführen
- [ ] `pnpm seed` → textbausteine-Tabelle hat ~30 Reihen
- [ ] `pnpm dev` → Magic-Link-Test → Plan-Viewer öffnen → Pin droppen,
      verschieben, mit Foto annotieren
- [ ] Cmd+K testen, dann `g+d` → springt zu Dashboard
- [ ] Mikrofon-Button im Mängel-Detail (Chrome/Edge): Spracheingabe für
      Beschreibung
- [ ] Textbaustein-Dropdown: 'Putz nicht eben' wählen → wird in
      description appendet

## Folgeschritte

Nach Merge: 'Live-Schaltung in 10 Minuten' aus `docs/HANDOFF.md` durchgehen.
Tag `v1.0.0-rc2` ist lokal gesetzt; Tag-Push schlägt vom Container-Proxy
weiterhin mit RPC 403 fehl (siehe OQ-011). Bitte lokal nachschicken:

```bash
git push origin v1.0.0-rc2
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_