### PR TITLE
fix(checklisten): missing FROM-clause for checklists

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,20 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 
 ---
 
+## [unreleased] — 2026-04-30 (post-rc2)
+
+### Fixed
+- `GET /<projectId>/checklisten` warf 500 mit
+  `PostgresError: missing FROM-clause entry for table "checklists"`.
+  In `listChecklistsWithProgress` referenzierten zwei Aggregat-Queries
+  (doneCount, photoCount) `checklists.id` im WHERE, ohne die Tabelle in
+  FROM zu joinen. Postgres validiert Spalten beim PARSE — Query schlug
+  schon vor Ausführung fehl. Fix: `eq(checklistSections.checklistId, cl.id)`
+  (checklist_sections ist via innerJoin schon im FROM, hat den Link auf
+  die Checkliste). Minimal-invasiv, eine Spalte pro Stelle.
+
+---
+
 ## [1.0.0-rc2] — 2026-04-30
 
 ### Migrations (Phase A nachgereicht + neu)

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,5 +1,9 @@
 # PROGRESS
 
+**Hotfix post-rc2** (2026-04-30): `/checklisten` 500er behoben — falsche
+FROM-clause in 2 Aggregat-Queries (`listChecklistsWithProgress`).
+PR-Body: siehe `claude/fix-checklisten-from-clause`.
+
 **BUILD COMPLETE v1.0.0-rc2** — Migration-Fix, Premium-UX, DocMa-Features, Deploy-Ready.
 
 Vorgänger: `v1.0.0-rc1` (alle 4 Phasen aus `MASTER_SPEC.md` umgesetzt).

--- a/src/lib/db/checklistQueries.ts
+++ b/src/lib/db/checklistQueries.ts
@@ -103,7 +103,7 @@ export async function listChecklistsWithProgress(projectId: string): Promise<Che
       .where(
         and(
           eq(checklistProgress.projectId, projectId),
-          eq(checklists.id, cl.id),
+          eq(checklistSections.checklistId, cl.id),
           eq(checklistProgress.done, true)
         )
       );
@@ -114,7 +114,7 @@ export async function listChecklistsWithProgress(projectId: string): Promise<Che
       .innerJoin(checklistProgress, eq(checklistProgress.id, checklistPhotos.progressId))
       .innerJoin(checklistItems, eq(checklistItems.id, checklistProgress.itemId))
       .innerJoin(checklistSections, eq(checklistSections.id, checklistItems.sectionId))
-      .where(and(eq(checklistProgress.projectId, projectId), eq(checklists.id, cl.id)));
+      .where(and(eq(checklistProgress.projectId, projectId), eq(checklistSections.checklistId, cl.id)));
 
     result.push({
       id: cl.id,


### PR DESCRIPTION
## Stacktrace

```
PostgresError: missing FROM-clause entry for table "checklists"
  at file:///.../postgres@3.4.9/cjs/src/connection.js
  at … (im SvelteKit-Server-Load auf
  src/routes/(app)/[projectId]/checklisten/+page.server.ts)
```

Auftritt: jeder Aufruf der Checklisten-Übersichtsseite → 500.

## Diagnose (1 Satz)

`listChecklistsWithProgress()` baute zwei Aggregat-Queries
(`doneCount`, `photoCount`), die im `WHERE` `checklists.id` referenzierten,
obwohl `checklists` nie via `from()` oder `innerJoin()` in die FROM-Klausel
aufgenommen wurde — Postgres validiert Spalten beim PARSE, bricht ab.

## Diff-Zusammenfassung

`src/lib/db/checklistQueries.ts`, **2 Stellen**, je eine Spalte:

```diff
- eq(checklists.id, cl.id)
+ eq(checklistSections.checklistId, cl.id)
```

`checklist_sections` ist via `innerJoin` bereits im FROM — die FK-Spalte
`checklist_id` darauf hält die Verknüpfung zur Checkliste, also derselbe
Filter, gleichwertige Selektivität, valide SQL.

Keine Query-Umstrukturierung, keine Migration, keine API-Änderung.

## Test plan

- [x] `pnpm check` → 0 errors
- [x] `pnpm test` → 15/15 grün (Engine-Tests berührt nicht)
- [x] `pnpm build` → OK
- [ ] Live nach Merge: `/<projectId>/checklisten` lädt 200, zeigt 31 Karten
      (vorausgesetzt `seed.sql` ist in Production schon gelaufen — siehe PR #4)

## Keine Migrations diesmal

Reine Code-Änderung. Hotfix.

## Out-of-scope

- Regression-Test via Drizzle `toSQL()` wäre nice — aber zu eng an
  Drizzle-Internals gekoppelt; der Smoke-Test in PR #4-Test-plan deckt
  das praktisch ab.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_