### PR TITLE
feat(maengel/plan-crop): 400×300 Plan-Crop pro Mangel + im PDF-Report

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,18 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 
 ---
 
-## [unreleased] — 2026-04-30 (post-rc2)
+## [unreleased] — post-rc2
+
+### Added
+- feat(maengel/plan-crop): Beim Pin-Setzen wird ein 400×300px-JPEG-Crop
+  um den Pin generiert (rotes Markierungs-Symbol mittig), in
+  `defect-crops/<projectId>/<draftId>.jpg` hochgeladen und als
+  `defects.plan_crop_path` referenziert. PDF-Mängelreport zeigt den
+  Crop oberhalb der Fotos. Migration 0007 nötig. Existierende Mängel
+  ohne Crop bleiben funktional (NULL-Handling). (PR #7)
 
 ### Fixed
+- fix(checklisten/detail): empty-progress 500er. (PR #6, separat)
 - `GET /<projectId>/checklisten` warf 500 mit
   `PostgresError: missing FROM-clause entry for table "checklists"`.
   In `listChecklistsWithProgress` referenzierten zwei Aggregat-Queries

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,8 +1,12 @@
 # PROGRESS
 
-**Hotfix post-rc2** (2026-04-30): `/checklisten` 500er behoben — falsche
-FROM-clause in 2 Aggregat-Queries (`listChecklistsWithProgress`).
-PR-Body: siehe `claude/fix-checklisten-from-clause`.
+**post-rc2 Session** (heute):
+- PR #5 (gemerged): /checklisten FROM-clause-Fix
+- PR #6 (offen, CI-Re-Run nötig): /checklisten/[id] empty-progress IN()-Fix
+- PR #7 (offen, **Migration 0007**): Plan-Crop für Mängel — 400×300 JPEG
+  beim Pin-Setzen, im PDF-Bericht oberhalb der Fotos
+
+Als Nächstes: PR #8 (Gantt-Drag&Drop-Dependencies).
 
 **BUILD COMPLETE v1.0.0-rc2** — Migration-Fix, Premium-UX, DocMa-Features, Deploy-Ready.
 

--- a/src/lib/db/defectQueries.ts
+++ b/src/lib/db/defectQueries.ts
@@ -31,6 +31,7 @@ export async function listDefects(projectId: string) {
       page: defects.page,
       xPct: defects.xPct,
       yPct: defects.yPct,
+      planCropPath: defects.planCropPath,
       createdAt: defects.createdAt
     })
     .from(defects)
@@ -88,6 +89,7 @@ export type CreateDefectInput = {
   page?: number | null;
   xPct?: number | null;
   yPct?: number | null;
+  planCropPath?: string | null;
   deadline?: string | null;
   priority?: number;
   createdBy: string;
@@ -110,6 +112,7 @@ export async function createDefect(input: CreateDefectInput) {
       page: input.page ?? null,
       xPct: input.xPct != null ? input.xPct.toString() : null,
       yPct: input.yPct != null ? input.yPct.toString() : null,
+      planCropPath: input.planCropPath ?? null,
       deadline: input.deadline ?? null,
       priority: input.priority ?? 2,
       status: 'open',

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -248,6 +248,7 @@ export const defects = pgTable('defects', {
   page: integer('page'),
   xPct: numeric('x_pct'),
   yPct: numeric('y_pct'),
+  planCropPath: text('plan_crop_path'),
   apartmentId: uuid('apartment_id').references(() => apartments.id),
   gewerkId: uuid('gewerk_id').references(() => gewerke.id),
   contactId: uuid('contact_id').references(() => contacts.id),

--- a/src/lib/pdf/defectReport.ts
+++ b/src/lib/pdf/defectReport.ts
@@ -25,6 +25,9 @@ export type ReportDefect = {
   deadline: string | null;
   apartmentLabel?: string | null;
   photoUrls: string[];
+  /** Pre-rendered Plan-Crop (400×300) als signed-URL — wenn vorhanden,
+   * landet er oben über den Fotos im Report. */
+  planCropUrl?: string | null;
   planSignedUrl?: string | null;
   page?: number | null;
   xPct?: number | null;
@@ -156,6 +159,31 @@ export async function generateDefectReport(input: ReportInput): Promise<Blob> {
       cursor -= 6;
     }
 
+    // Plan-Crop (400×300, mit rotem Pin-Marker), wenn vorhanden — oberhalb der Fotos
+    if (d.planCropUrl) {
+      const bytes = await fetchImageBytes(d.planCropUrl);
+      if (bytes) {
+        let img: PDFImage | null = null;
+        try { img = await pdf.embedJpg(bytes); } catch (_e) {
+          try { img = await pdf.embedPng(bytes); } catch (_e2) { img = null; }
+        }
+        if (img) {
+          const cropW = 320;
+          const cropH = 240;
+          cursor -= cropH;
+          page.drawText('Plan-Ausschnitt', {
+            x: MARGIN, y: cursor + cropH + 4, size: 9, font: helv, color: MUTED
+          });
+          page.drawImage(img, { x: MARGIN, y: cursor, width: cropW, height: cropH });
+          page.drawRectangle({
+            x: MARGIN, y: cursor, width: cropW, height: cropH,
+            borderColor: rgb(0.7, 0.7, 0.7), borderWidth: 0.5
+          });
+          cursor -= 12;
+        }
+      }
+    }
+
     // Up to 2 photos side-by-side
     const photos = d.photoUrls.slice(0, 2);
     if (photos.length > 0) {
@@ -230,6 +258,7 @@ export async function downloadGewerkReport(args: {
     deadline: string | null;
     apartmentLabel?: string | null;
     photoStoragePaths: string[];
+    planCropPath?: string | null;
     planStoragePath?: string | null;
     page?: number | null;
     xPct?: number | null;
@@ -245,6 +274,8 @@ export async function downloadGewerkReport(args: {
     }
     let planSignedUrl: string | null = null;
     if (d.planStoragePath) planSignedUrl = await getSignedUrl('plans', d.planStoragePath, 600);
+    let planCropUrl: string | null = null;
+    if (d.planCropPath) planCropUrl = await getSignedUrl('defect-crops', d.planCropPath, 600);
     reportDefects.push({
       shortId: d.shortId,
       title: d.title,
@@ -253,6 +284,7 @@ export async function downloadGewerkReport(args: {
       deadline: d.deadline,
       apartmentLabel: d.apartmentLabel,
       photoUrls,
+      planCropUrl,
       planSignedUrl,
       page: d.page,
       xPct: d.xPct,

--- a/src/lib/storage/photos.ts
+++ b/src/lib/storage/photos.ts
@@ -86,3 +86,30 @@ export async function getSignedUrl(bucket: string, path: string, expiresIn = 300
   if (error) return null;
   return data.signedUrl;
 }
+
+/**
+ * Upload a 400×300 plan-crop blob (already cropped client-side from the
+ * rendered PDF canvas) to the defect-crops bucket. Pfad-RLS expects
+ * "<projectId>/..." als ersten Segment.
+ *
+ * Wir benutzen "<projectId>/<defectId>.jpg" als Pfad — ein Crop pro Mangel,
+ * Re-Upload via upsert: true überschreibt den alten.
+ *
+ * Falls bei Mangel-Anlage die defectId noch nicht existiert (Pre-Submit
+ * Upload), nutze einen Draft-UUID — der Mangel referenziert dann
+ * "<projectId>/<draftId>.jpg". Server-Action kennt den Pfad.
+ */
+export async function uploadPlanCrop(
+  projectId: string,
+  defectIdOrDraft: string,
+  blob: Blob
+): Promise<{ path: string }> {
+  const sb = getSupabaseBrowser();
+  const path = `${projectId}/${defectIdOrDraft}.jpg`;
+  const { error } = await sb.storage.from('defect-crops').upload(path, blob, {
+    contentType: 'image/jpeg',
+    upsert: true
+  });
+  if (error) throw error;
+  return { path };
+}

--- a/src/lib/util/crop.ts
+++ b/src/lib/util/crop.ts
@@ -1,0 +1,84 @@
+/**
+ * Erzeuge einen 400×300px-JPEG-Ausschnitt um einen Pin auf einem
+ * gerenderten Canvas (z.B. eine Plan-Seite via PDF.js).
+ *
+ * Strategie: Source-Region rund um den Pin sampeln, mit roter Markierung
+ * an der exakten Pin-Position überlagern, dann als JPEG-Blob zurück geben.
+ *
+ * - srcCanvas: das vollständig gerenderte Plan-Canvas
+ * - xPct/yPct: Pin-Position (0..100)
+ * - returns: 400×300 JPEG-Blob (q=0.82)
+ *
+ * Pure (kein DOM-Effekt außerhalb eines temporären Canvas).
+ */
+export const PLAN_CROP_W = 400;
+export const PLAN_CROP_H = 300;
+
+export async function cropPlanAroundPin(
+  srcCanvas: HTMLCanvasElement,
+  xPct: number,
+  yPct: number
+): Promise<Blob> {
+  const sw = srcCanvas.width;
+  const sh = srcCanvas.height;
+  if (sw === 0 || sh === 0) throw new Error('Source canvas hat keine Dimensionen.');
+
+  // Pin in Pixeln
+  const px = (xPct / 100) * sw;
+  const py = (yPct / 100) * sh;
+
+  // Source-Region (zentriert um den Pin), in Source-Pixel-Koordinaten.
+  // Wir wollen 400×300 sehen, also wenn das Source-Canvas größer ist, einen
+  // Ausschnitt nehmen; wenn kleiner, hochskalieren (bleibt sichtbar, ggf.
+  // verpixelt — besser als gar kein Crop).
+  const targetAspect = PLAN_CROP_W / PLAN_CROP_H;
+  // Wir samplen einen Source-Bereich mit 400×300 Aspect Ratio bei einer
+  // Source-Höhe von min(sh, 600px) — das ergibt einen sinnvollen Zoom.
+  const srcH = Math.min(sh, 600);
+  const srcW = srcH * targetAspect;
+
+  let sx = px - srcW / 2;
+  let sy = py - srcH / 2;
+  // Clamp ins Bild
+  if (sx < 0) sx = 0;
+  if (sy < 0) sy = 0;
+  if (sx + srcW > sw) sx = sw - srcW;
+  if (sy + srcH > sh) sy = sh - srcH;
+
+  const out = document.createElement('canvas');
+  out.width = PLAN_CROP_W;
+  out.height = PLAN_CROP_H;
+  const ctx = out.getContext('2d');
+  if (!ctx) throw new Error('Kein 2D-Context auf Crop-Canvas.');
+
+  // Bild-Region zeichnen
+  ctx.drawImage(srcCanvas, sx, sy, srcW, srcH, 0, 0, PLAN_CROP_W, PLAN_CROP_H);
+
+  // Pin-Marker zeichnen (roter Kreis mit weißem Inneren-Ring)
+  const markerX = ((px - sx) / srcW) * PLAN_CROP_W;
+  const markerY = ((py - sy) / srcH) * PLAN_CROP_H;
+  const r = 14;
+
+  ctx.strokeStyle = '#E30613';
+  ctx.lineWidth = 4;
+  ctx.beginPath();
+  ctx.arc(markerX, markerY, r, 0, 2 * Math.PI);
+  ctx.stroke();
+  ctx.strokeStyle = '#ffffff';
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.arc(markerX, markerY, r - 3, 0, 2 * Math.PI);
+  ctx.stroke();
+  ctx.fillStyle = '#E30613';
+  ctx.beginPath();
+  ctx.arc(markerX, markerY, 3, 0, 2 * Math.PI);
+  ctx.fill();
+
+  return await new Promise<Blob>((resolve, reject) =>
+    out.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('toBlob() failed'))),
+      'image/jpeg',
+      0.82
+    )
+  );
+}

--- a/src/routes/(app)/[projectId]/maengel/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/+page.svelte
@@ -63,6 +63,7 @@
             status: d.status,
             deadline: d.deadline,
             photoStoragePaths: photos.map((p) => p.storagePath),
+            planCropPath: d.planCropPath ?? null,
             page: d.page,
             xPct: d.xPct != null ? Number(d.xPct) : null,
             yPct: d.yPct != null ? Number(d.yPct) : null

--- a/src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.server.ts
@@ -37,6 +37,7 @@ const pinSchema = z.object({
   xPct: z.coerce.number().min(0).max(100),
   yPct: z.coerce.number().min(0).max(100),
   priority: z.coerce.number().int().min(1).max(3).default(2),
+  planCropPath: z.string().min(3).max(300).optional(),
   photos: z.string().optional()
 });
 
@@ -73,6 +74,7 @@ export const actions: Actions = {
       xPct: parsed.data.xPct,
       yPct: parsed.data.yPct,
       priority: parsed.data.priority,
+      planCropPath: parsed.data.planCropPath ?? null,
       createdBy: locals.user.id
     });
 

--- a/src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.svelte
@@ -96,6 +96,21 @@
   async function createPin() {
     if (!pinDraft || !title.trim()) return;
     creating = true;
+
+    // Plan-Crop client-seitig generieren (best-effort, blockiert nicht)
+    let planCropPath: string | null = null;
+    try {
+      const { cropPlanAroundPin } = await import('$lib/util/crop');
+      const { uploadPlanCrop } = await import('$lib/storage/photos');
+      const blob = await cropPlanAroundPin(canvasEl, pinDraft.xPct, pinDraft.yPct);
+      const draftId = crypto.randomUUID();
+      const { path } = await uploadPlanCrop(parent.project.id, draftId, blob);
+      planCropPath = path;
+    } catch (err) {
+      // Nicht blockierend — Mangel wird auch ohne Crop angelegt
+      console.warn('[plan-crop] failed:', err);
+    }
+
     const fd = new FormData();
     fd.append('title', title);
     fd.append('gewerkId', gewerkId);
@@ -104,6 +119,7 @@
     fd.append('xPct', pinDraft.xPct.toFixed(2));
     fd.append('yPct', pinDraft.yPct.toFixed(2));
     fd.append('priority', '2');
+    if (planCropPath) fd.append('planCropPath', planCropPath);
     if (pinDraftPhotos.length > 0) {
       fd.append('photos', JSON.stringify(
         pinDraftPhotos.map((p) => ({ storagePath: p.storagePath, width: p.width, height: p.height }))

--- a/supabase/migrations/0007_defect_plan_crop.sql
+++ b/supabase/migrations/0007_defect_plan_crop.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- 0007_defect_plan_crop
+-- Plan-Crop pro Mangel: 400×300px JPEG-Ausschnitt um den Pin.
+--
+-- - defects.plan_crop_path: nullable text — Storage-Pfad
+--   (z.B. "<projectId>/<defectId>.jpg" im Bucket defect-crops)
+-- - Storage-Bucket "defect-crops" privat + Pfad-basierte RLS analog
+--   defect-photos / plans / musterdetails (erste URL-Komponente =
+--   Project-ID, gegen project_members geprüft via is_project_member).
+--
+-- Idempotent + transaktional. Backwards-compatible: existierende
+-- Mängel ohne Crop laufen weiter (NULL).
+-- ============================================================
+
+BEGIN;
+
+ALTER TABLE public.defects
+  ADD COLUMN IF NOT EXISTS plan_crop_path text;
+
+-- Storage-Bucket
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('defect-crops', 'defect-crops', false)
+ON CONFLICT (id) DO NOTHING;
+
+DROP POLICY IF EXISTS "members rw defect-crops" ON storage.objects;
+CREATE POLICY "members rw defect-crops" ON storage.objects
+  FOR ALL TO authenticated
+  USING (
+    bucket_id = 'defect-crops'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  )
+  WITH CHECK (
+    bucket_id = 'defect-crops'
+    AND public.is_project_member((split_part(name, '/', 1))::uuid)
+  );
+
+COMMIT;


### PR DESCRIPTION
## ⚠️ MIGRATIONS — Laurenz muss SQL manuell in Supabase SQL Editor ausführen, bevor Merge

```
supabase/migrations/0007_defect_plan_crop.sql
```

Das File ist transaktional + idempotent (`BEGIN`/`COMMIT`, `ADD COLUMN
IF NOT EXISTS`, `ON CONFLICT DO NOTHING`, `DROP POLICY IF EXISTS`).

Nach dem Run:
- Spalte `defects.plan_crop_path text` (nullable)
- Neuer Storage-Bucket `defect-crops` (privat)
- Pfad-basierte RLS-Policy auf `storage.objects` für diesen Bucket

Self-Merge ist gemäß Regelwerk **nicht zulässig**, weil dieser PR eine
Migration enthält. Ich lasse offen.

## Was es macht

Wenn der Bauleiter auf einem Plan einen Pin setzt, generiert der
Plan-Viewer client-seitig einen **400×300px JPEG-Ausschnitt** um den
Pin (mit rotem Markierungs-Symbol an der exakten Pin-Position),
lädt ihn in Storage hoch und speichert den Pfad am Mangel.

Im PDF-Mängelbericht (an den Handwerker) landet der Plan-Ausschnitt
**oberhalb der Mängel-Fotos** mit Label „Plan-Ausschnitt" — der
Handwerker sieht sofort _wo_ auf dem Plan der Mangel sitzt, ohne den
ganzen Plan mitschicken zu müssen.

## Diff im Überblick (11 Files)

| File | Was |
|---|---|
| `supabase/migrations/0007_defect_plan_crop.sql` | NEU — Spalte + Bucket + RLS |
| `src/lib/db/schema.ts` | + `planCropPath: text('plan_crop_path')` |
| `src/lib/db/defectQueries.ts` | + Field in `CreateDefectInput`, `createDefect()`, `listDefects()` |
| `src/lib/util/crop.ts` | NEU — `cropPlanAroundPin(canvas, xPct, yPct) → Blob` |
| `src/lib/storage/photos.ts` | + `uploadPlanCrop()` |
| `src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.svelte` | createPin() ruft Crop+Upload auf |
| `src/routes/(app)/[projectId]/maengel/plaene/[planId]/+page.server.ts` | pinSchema + `planCropPath` |
| `src/routes/(app)/[projectId]/maengel/+page.svelte` | reicht `planCropPath` an `downloadGewerkReport` |
| `src/lib/pdf/defectReport.ts` | rendert Crop oberhalb der Fotos |
| `docs/CHANGELOG.md` + `docs/PROGRESS.md` | Doku |

11 Files knapp über dem 8er-Soft-Limit, aber alles eng-gekoppelt zum
einen Feature (kein "by the way"-Refactoring).

## Crop-Strategie

`cropPlanAroundPin()` nimmt das gerenderte Plan-Canvas, sampelt einen
Source-Bereich rund um den Pin mit fester 4:3-Aspect-Ratio (Quell-Höhe
= min(Canvas-Höhe, 600px) — gibt einen vernünftigen Zoom unabhängig vom
PDF-DPI). Zeichnet den ausgeschnittenen Bereich in ein 400×300-Canvas,
malt den roten Pin-Marker (Außenkreis, weißer Inner-Ring, roter Punkt),
exportiert als JPEG q=0.82.

Best-effort: wenn die Crop-Generierung fehlschlägt (z.B. Canvas leer
weil PDF noch lädt), wird der Mangel trotzdem angelegt — `try/catch`
um die ganze Crop-Pipeline.

## Backwards-Compatibility

Existierende Mängel ohne `plan_crop_path` (alle bestehenden) bleiben
funktional. Der PDF-Report-Code skippt die Crop-Sektion via
`if (d.planCropUrl)`-Guard. Niemand muss zwangs-rebackfilled werden.

## Self-Review

- [x] Kein `console.log` produktiv (`console.warn` für Crop-Fail-Fallback ist intentional)
- [x] Edge-Case: leeres Canvas → wirft, wird gefangen, Mangel ohne Crop
- [x] Edge-Case: `plan_crop_path = NULL` → Report skippt Sektion sauber
- [x] RLS: Pfad-basierte Policy analog zu `defect-photos`/`plans` (erstes Segment = projectId)
- [x] Mobile: keine spezielle Geste, Crop läuft bei jedem Submit
- [x] DSGVO: Crop ist Bauplan-Ausschnitt, kein PII
- [x] No n+1: Crop wird genau einmal pro Mangel-Anlage erzeugt, im PDF-Generator pro Mangel ein signed URL
- [x] type-check 0 errors, tests 15/15 grün, build OK

## Test plan (nach Migration-Run)

- [ ] Plan öffnen, leeres Feld antippen → "Mangel anlegen"-Sheet → Titel + Speichern
- [ ] In Supabase: `defects.plan_crop_path` ist gesetzt für den neuen Mangel
- [ ] Storage Browser: `defect-crops/<projectId>/<id>.jpg` ist sichtbar (400×300)
- [ ] Crop zeigt roten Pin in der Mitte
- [ ] PDF-Report für das Gewerk generieren → Mangel-Seite zeigt Plan-Ausschnitt oben
- [ ] Existierender Mangel ohne Crop: Report rendert weiter ohne Fehler

## Out-of-scope (Phase 5+)

- Re-Crop wenn Pin per Drag verschoben wird (heute: Crop wird nur beim
  Anlegen erzeugt; Drag aktualisiert `xPct`/`yPct` aber regeneriert keinen
  Crop)
- Mehrere Crops pro Mangel (z.B. einer pro Plan-Version)
- Zoom-Stufen-Auswahl im Crop (heute: feste Höhe 600px Source)

Diese Punkte landen in `docs/OPEN_QUESTIONS.md` als Phase-5-Kandidaten.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_