### PR TITLE
feat(bauzeit/deps): Drag&Drop-Dependencies (MS-Project-Niveau)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,20 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 
 ---
 
-## [unreleased] — 2026-04-30 (post-rc2)
+## [unreleased] — post-rc2
+
+### Added
+- feat(bauzeit/deps): Drag&Drop-Dependencies wie in MS-Project. Hover-
+  Handles auf jeder Bar (Start + Ende), Drag von einem Handle zu einer
+  anderen Bar erzeugt Abhängigkeit (Pred-Handle × Succ-Handle bestimmt
+  Typ: FS/SS/FF/SF). Mobile-Fallback: right-click oder long-press auf
+  Handle aktiviert Connector-Mode, dann Tap auf Ziel-Bar. Pfeile als
+  rechtwinklige SVG-Polylinien zwischen Bars (mit `<marker>`-Pfeil).
+  Click auf Pfeil öffnet Edit-Dialog (Typ + Lag in AT + Löschen).
+  Server actions: createDep/updateDep/deleteDep mit Zod-Validation,
+  RLS-Check via project-membership der Tasks. Idempotent (Duplikat
+  wird zu Update). Keine Migration nötig — `task_dependencies` existiert
+  schon. (PR #8)
 
 ### Fixed
 - `GET /<projectId>/checklisten` warf 500 mit

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,8 +1,13 @@
 # PROGRESS
 
-**Hotfix post-rc2** (2026-04-30): `/checklisten` 500er behoben — falsche
-FROM-clause in 2 Aggregat-Queries (`listChecklistsWithProgress`).
-PR-Body: siehe `claude/fix-checklisten-from-clause`.
+**post-rc2 Session** (heute):
+- PR #5 (gemerged): /checklisten FROM-clause-Fix
+- PR #6 (offen, CI-Re-Run nötig): /checklisten/[id] empty-progress IN()-Fix
+- PR #7 (offen, **Migration 0007**): Plan-Crop für Mängel
+- PR #8 (offen, KEINE Migration): Gantt-Drag&Drop-Dependencies
+  (MS-Project-Niveau, FS/SS/FF/SF, Mobile-Connector-Mode, Edit-Popover)
+
+Als Nächstes: PR #9 (Design-Politur).
 
 **BUILD COMPLETE v1.0.0-rc2** — Migration-Fix, Premium-UX, DocMa-Features, Deploy-Ready.
 

--- a/src/lib/components/Gantt.svelte
+++ b/src/lib/components/Gantt.svelte
@@ -14,15 +14,36 @@
   };
 
   type Baseline = { taskId: string; plannedStart: string; plannedEnd: string };
+  export type Dependency = {
+    id: string;
+    predecessorId: string;
+    successorId: string;
+    type: 'FS' | 'SS' | 'FF' | 'SF';
+    lagDays: number;
+  };
+  type DepHandle = 'start' | 'end';
   type Props = {
     tasks: GTask[];
     onSelect?: (taskId: string) => void;
     onMove?: (taskId: string, newStart: string, newEnd: string) => void;
+    onDepCreate?: (predecessorId: string, successorId: string, predHandle: DepHandle, succHandle: DepHandle) => void;
+    onDepClick?: (depId: string) => void;
     criticalPathIds?: Set<string>;
     baseline?: Baseline[];
+    dependencies?: Dependency[];
     lookaheadWeeks?: 0 | 3 | 4 | 6;
   };
-  let { tasks, onSelect, onMove, criticalPathIds = new Set<string>(), baseline = [], lookaheadWeeks = 0 }: Props = $props();
+  let {
+    tasks,
+    onSelect,
+    onMove,
+    onDepCreate,
+    onDepClick,
+    criticalPathIds = new Set<string>(),
+    baseline = [],
+    dependencies = [],
+    lookaheadWeeks = 0
+  }: Props = $props();
 
   let baselineMap = $derived.by(() => {
     const m = new Map<string, { plannedStart: string; plannedEnd: string }>();
@@ -229,6 +250,121 @@
     if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
     dragging = null;
   }
+
+  /* ===== Dependency Drag&Drop (Connector-Handles auf Bars) =====
+   *
+   * Hover über eine Bar zeigt zwei Handles (Start + End). Drag von einem
+   * Handle auf eine andere Bar (oder deren Handle) erzeugt eine Dependency.
+   *
+   * Mobile: kein Hover-State — stattdessen Long-Press auf einer Bar
+   * aktiviert den "Connector-Mode" (depMode = id), und der nächste Tap
+   * auf eine andere Bar erzeugt die Dependency.
+   */
+  let depDrag = $state<null | {
+    predecessorId: string;
+    predHandle: DepHandle;
+    pointerId: number;
+    cursorX: number; // relative zur timeline
+    cursorY: number;
+    startX: number;
+    startY: number;
+  }>(null);
+  let depMode = $state<{ id: string; handle: DepHandle } | null>(null); // Touch-Mode
+
+  function onHandlePointerDown(e: PointerEvent, taskId: string, handle: DepHandle) {
+    e.stopPropagation();
+    if (!onDepCreate) return;
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    const wrap = (e.currentTarget as HTMLElement).closest('.gantt-timeline');
+    if (!wrap) return;
+    const rect = wrap.getBoundingClientRect();
+    depDrag = {
+      predecessorId: taskId,
+      predHandle: handle,
+      pointerId: e.pointerId,
+      cursorX: e.clientX - rect.left,
+      cursorY: e.clientY - rect.top,
+      startX: e.clientX - rect.left,
+      startY: e.clientY - rect.top
+    };
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }
+  function onHandlePointerMove(e: PointerEvent) {
+    if (!depDrag || depDrag.pointerId !== e.pointerId) return;
+    const wrap = (e.currentTarget as HTMLElement).closest('.gantt-timeline');
+    if (!wrap) return;
+    const rect = wrap.getBoundingClientRect();
+    depDrag = { ...depDrag, cursorX: e.clientX - rect.left, cursorY: e.clientY - rect.top };
+  }
+  function onHandlePointerUp(e: PointerEvent) {
+    if (!depDrag || depDrag.pointerId !== e.pointerId) return;
+    // Find target bar at the cursor position
+    const target = document.elementFromPoint(e.clientX, e.clientY);
+    const targetBar = target?.closest('[data-task-id]') as HTMLElement | null;
+    const targetTaskId = targetBar?.dataset.taskId;
+    const targetHandleAttr = targetBar?.dataset.handle as DepHandle | undefined;
+    if (targetTaskId && targetTaskId !== depDrag.predecessorId) {
+      // Default: target's start (FS-style)
+      const succHandle: DepHandle = targetHandleAttr ?? 'start';
+      onDepCreate?.(depDrag.predecessorId, targetTaskId, depDrag.predHandle, succHandle);
+    }
+    depDrag = null;
+  }
+
+  function activateDepMode(taskId: string, handle: DepHandle) {
+    depMode = { id: taskId, handle };
+  }
+  function applyDepMode(targetTaskId: string) {
+    if (!depMode || !onDepCreate) return;
+    if (targetTaskId === depMode.id) {
+      depMode = null;
+      return;
+    }
+    onDepCreate(depMode.id, targetTaskId, depMode.handle, 'start');
+    depMode = null;
+  }
+
+  /* Layout-Lookup: y-Position einer Task in der visible-Liste = row-index * 32 + 16 (Mitte) */
+  let visibleIndex = $derived.by(() => {
+    const m = new Map<string, number>();
+    visible.forEach((t, i) => m.set(t.id, i));
+    return m;
+  });
+
+  function barEdges(taskId: string): { x1: number; x2: number; y: number } | null {
+    const t = tasks.find((x) => x.id === taskId);
+    const idx = visibleIndex.get(taskId);
+    if (!t || idx === undefined) return null;
+    const x1 = offsetPx(t.startDate);
+    const x2 = x1 + Math.max(8, (daysBetween(t.startDate, t.endDate) + 1) * dayWidth());
+    const y = idx * 32 + 16; // Mitte der Bar
+    return { x1, x2, y };
+  }
+
+  /** Pfad-Generator: rechteckige Polylinie zwischen zwei Punkten,
+   * ähnlich MS-Project: vom predecessor-Edge nach rechts/links,
+   * dann vertikal, dann zur successor-Bar. */
+  function depPath(d: Dependency): string | null {
+    const pred = barEdges(d.predecessorId);
+    const succ = barEdges(d.successorId);
+    if (!pred || !succ) return null;
+    const fromX = d.type === 'SS' || d.type === 'SF' ? pred.x1 : pred.x2;
+    const toX = d.type === 'FF' || d.type === 'SF' ? succ.x2 : succ.x1;
+    const fromDir = d.type === 'SS' || d.type === 'SF' ? -1 : 1;
+    const toDir = d.type === 'FF' || d.type === 'SF' ? 1 : -1;
+    // Fahre 8px in fromDir, dann vertikal, dann 8px gegen toDir
+    const stub = 10;
+    const elbow1 = fromX + fromDir * stub;
+    const elbow2 = toX + toDir * stub;
+    return `M ${fromX} ${pred.y} L ${elbow1} ${pred.y} L ${elbow1} ${succ.y} L ${elbow2} ${succ.y} L ${toX} ${succ.y}`;
+  }
+
+  function depTipPos(d: Dependency): { x: number; y: number } | null {
+    const succ = barEdges(d.successorId);
+    if (!succ) return null;
+    const tipDir = d.type === 'FF' || d.type === 'SF' ? 1 : -1;
+    return { x: succ.x1 + (tipDir < 0 ? 0 : succ.x2 - succ.x1), y: succ.y };
+  }
 </script>
 
 <div class="gantt-toolbar">
@@ -303,12 +439,17 @@
                 class:dimmed={criticalPathIds.size > 0 && !criticalPathIds.has(t.id)}
                 class:dragging={dragging?.id === t.id && dragging.armed}
                 class:armed-touch={dragging?.id === t.id && dragging.armed && dragging.pointerType !== 'mouse'}
+                class:dep-mode-target={depMode && depMode.id !== t.id}
                 style={`left:${offsetPx(t.startDate) + (dragging?.id === t.id && dragging.armed ? dragging.previewOffset : 0)}px;width:${widthFor(t)}px;background:${t.color ?? '#3B6CC4'}`}
-                onclick={() => { if (!dragging || !dragging.moved) onSelect?.(t.id); }}
+                onclick={() => {
+                  if (depMode) { applyDepMode(t.id); return; }
+                  if (!dragging || !dragging.moved) onSelect?.(t.id);
+                }}
                 onpointerdown={(e) => onBarPointerDown(e, t)}
                 onpointermove={onBarPointerMove}
                 onpointerup={onBarPointerUp}
                 onpointercancel={onBarPointerCancel}
+                data-task-id={t.id}
               >
                 <span class="gantt-bar-label">{t.name}</span>
                 <span class="gantt-bar-tooltip" role="tooltip">
@@ -318,14 +459,81 @@
                     <span class="tooltip-crit">Kritisch — Verzögerung wirkt 1:1 auf Übergabe</span>
                   {/if}
                 </span>
+                {#if onDepCreate}
+                  <span
+                    class="gantt-dep-handle gantt-dep-handle-start"
+                    role="button"
+                    aria-label="Dependency vom Anfang ziehen"
+                    data-task-id={t.id}
+                    data-handle="start"
+                    onpointerdown={(e) => onHandlePointerDown(e, t.id, 'start')}
+                    onpointermove={onHandlePointerMove}
+                    onpointerup={onHandlePointerUp}
+                    oncontextmenu={(e) => { e.preventDefault(); activateDepMode(t.id, 'start'); }}
+                  ></span>
+                  <span
+                    class="gantt-dep-handle gantt-dep-handle-end"
+                    role="button"
+                    aria-label="Dependency vom Ende ziehen"
+                    data-task-id={t.id}
+                    data-handle="end"
+                    onpointerdown={(e) => onHandlePointerDown(e, t.id, 'end')}
+                    onpointermove={onHandlePointerMove}
+                    onpointerup={onHandlePointerUp}
+                    oncontextmenu={(e) => { e.preventDefault(); activateDepMode(t.id, 'end'); }}
+                  ></span>
+                {/if}
               </button>
             {/if}
           </div>
         {/each}
       </div>
+
+      {#if dependencies.length > 0 || depDrag}
+        <svg class="gantt-deps" width="100%" height="100%" preserveAspectRatio="none">
+          <defs>
+            <marker id="gantt-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="rgba(15,15,16,0.55)"></path>
+            </marker>
+            <marker id="gantt-arrow-active" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--red)"></path>
+            </marker>
+          </defs>
+          {#each dependencies as d (d.id)}
+            {@const path = depPath(d)}
+            {#if path}
+              <path
+                class="gantt-dep-arrow"
+                d={path}
+                marker-end="url(#gantt-arrow)"
+                onclick={() => onDepClick?.(d.id)}
+                role="button"
+                aria-label={`Dependency ${d.type}${d.lagDays ? ' Lag ' + d.lagDays : ''}`}
+              ></path>
+            {/if}
+          {/each}
+          {#if depDrag}
+            <line
+              class="gantt-dep-drag"
+              x1={depDrag.startX}
+              y1={depDrag.startY}
+              x2={depDrag.cursorX}
+              y2={depDrag.cursorY}
+              marker-end="url(#gantt-arrow-active)"
+            ></line>
+          {/if}
+        </svg>
+      {/if}
     </div>
   </div>
 </div>
+
+{#if depMode}
+  <div class="dep-mode-banner" role="status">
+    <span>Tippe auf eine Bar zum Verbinden</span>
+    <button class="btn btn-ghost btn-sm" onclick={() => (depMode = null)}>Abbrechen</button>
+  </div>
+{/if}
 
 <style>
   .gantt-toolbar {
@@ -488,7 +696,66 @@
   @media (prefers-reduced-motion: reduce) { .gantt-bar.critical { animation: none; } }
   .gantt-bar.dragging { opacity: .7; cursor: grabbing; z-index: 9; }
   .gantt-bar.armed-touch { box-shadow: 0 0 0 3px var(--red), 0 4px 14px rgba(227, 6, 19, 0.35); }
-  .gantt-bar { touch-action: pan-y; }
+  .gantt-bar.dep-mode-target { box-shadow: 0 0 0 2px var(--red); animation: depPulse 1.4s ease-in-out infinite; }
+  @keyframes depPulse {
+    0%   { box-shadow: 0 0 0 2px var(--red); }
+    50%  { box-shadow: 0 0 0 5px rgba(227, 6, 19, 0.35); }
+    100% { box-shadow: 0 0 0 2px var(--red); }
+  }
+  @media (prefers-reduced-motion: reduce) { .gantt-bar.dep-mode-target { animation: none; } }
+  .gantt-bar { touch-action: pan-y; position: relative; }
+  .gantt-dep-handle {
+    position: absolute; top: 50%; transform: translateY(-50%);
+    width: 12px; height: 12px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 2px solid var(--ink-2);
+    border-radius: 50%;
+    cursor: crosshair;
+    opacity: 0;
+    transition: opacity var(--d-fast, 180ms) ease;
+    z-index: 11;
+  }
+  .gantt-bar:hover .gantt-dep-handle, .gantt-dep-handle:focus-visible { opacity: 1; }
+  .gantt-dep-handle:hover { background: var(--red); border-color: var(--red); }
+  .gantt-dep-handle-start { left: -8px; }
+  .gantt-dep-handle-end { right: -8px; }
+  @media (hover: none) {
+    /* Touch: Handles immer schwach sichtbar — Long-press wäre verwirrend */
+    .gantt-dep-handle { opacity: 0.55; }
+  }
+  .gantt-deps {
+    position: absolute; left: 0; top: 60px; right: 0; bottom: 0;
+    pointer-events: none; z-index: 5;
+  }
+  .gantt-dep-arrow {
+    fill: none;
+    stroke: rgba(15, 15, 16, 0.55);
+    stroke-width: 1.4;
+    pointer-events: stroke;
+    cursor: pointer;
+    transition: stroke var(--d-fast, 180ms) ease, stroke-width var(--d-fast, 180ms) ease;
+  }
+  .gantt-dep-arrow:hover {
+    stroke: var(--red);
+    stroke-width: 2.2;
+  }
+  .gantt-dep-drag {
+    stroke: var(--red);
+    stroke-width: 2;
+    stroke-dasharray: 4 3;
+    pointer-events: none;
+  }
+  .dep-mode-banner {
+    position: fixed; bottom: calc(80px + env(safe-area-inset-bottom)); left: 50%;
+    transform: translateX(-50%);
+    background: var(--ink); color: #fff;
+    padding: 10px 16px; border-radius: 999px;
+    box-shadow: var(--shadow-2);
+    display: flex; align-items: center; gap: 10px;
+    font-size: 13px; font-weight: 600;
+    z-index: 60;
+  }
+  .dep-mode-banner .btn { color: #fff; }
   .gantt-baseline {
     position: absolute; top: 22px; height: 4px;
     background: transparent;

--- a/src/routes/(app)/[projectId]/bauzeitenplan/+page.server.ts
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/+page.server.ts
@@ -2,8 +2,8 @@ import { redirect, fail } from '@sveltejs/kit';
 import { z } from 'zod';
 import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
-import { tasks, taskBaselines, gewerke, houses, apartments, activity } from '$lib/db/schema';
-import { eq, and, asc, desc } from 'drizzle-orm';
+import { tasks, taskBaselines, taskDependencies, gewerke, houses, apartments, activity } from '$lib/db/schema';
+import { eq, and, asc, desc, or } from 'drizzle-orm';
 import { loadGaisbachSample } from '$lib/db/projectQueries';
 import { getProjectTasksAndDeps, applyTaskUpdates } from '$lib/db/taskQueries';
 import { propagate, type EngineTask, type EngineDep } from '$lib/gantt/engine';
@@ -194,5 +194,110 @@ export const actions: Actions = {
       .from(taskBaselines)
       .where(and(eq(taskBaselines.projectId, params.projectId), eq(taskBaselines.snapshotLabel, label)));
     return { ok: true, baseline: rows };
+  },
+
+  /* ===== Dependency-Endpoints (PR #8) ===== */
+
+  createDep: async ({ request, params, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const schema = z.object({
+      predecessorId: z.string().uuid(),
+      successorId: z.string().uuid(),
+      type: z.enum(['FS', 'SS', 'FF', 'SF']).default('FS'),
+      lagDays: z.coerce.number().int().min(-365).max(365).default(0)
+    });
+    const parsed = schema.safeParse(fd);
+    if (!parsed.success) return fail(400, { error: 'Ungültige Eingabe.' });
+    if (parsed.data.predecessorId === parsed.data.successorId) {
+      return fail(400, { error: 'Pred und Succ sind identisch.' });
+    }
+
+    // Beide Tasks müssen ins selbe Projekt gehören (RLS schützt zusätzlich)
+    const taskCheck = await db
+      .select({ id: tasks.id, projectId: tasks.projectId })
+      .from(tasks)
+      .where(or(eq(tasks.id, parsed.data.predecessorId), eq(tasks.id, parsed.data.successorId)));
+    if (taskCheck.length !== 2) return fail(404, { error: 'Termine nicht gefunden.' });
+    if (!taskCheck.every((t) => t.projectId === params.projectId)) {
+      return fail(403, { error: 'Termine außerhalb des Projekts.' });
+    }
+
+    // Idempotent: bei Duplikat updaten statt failen
+    const existing = await db
+      .select()
+      .from(taskDependencies)
+      .where(
+        and(
+          eq(taskDependencies.predecessorId, parsed.data.predecessorId),
+          eq(taskDependencies.successorId, parsed.data.successorId)
+        )
+      )
+      .limit(1);
+
+    if (existing.length > 0) {
+      await db
+        .update(taskDependencies)
+        .set({ type: parsed.data.type, lagDays: parsed.data.lagDays })
+        .where(eq(taskDependencies.id, existing[0].id));
+      return { ok: true, depId: existing[0].id, updated: true };
+    }
+
+    const [row] = await db
+      .insert(taskDependencies)
+      .values({
+        predecessorId: parsed.data.predecessorId,
+        successorId: parsed.data.successorId,
+        type: parsed.data.type,
+        lagDays: parsed.data.lagDays
+      })
+      .returning();
+
+    await db.insert(activity).values({
+      projectId: params.projectId,
+      userId: locals.user.id,
+      type: 'dep_created',
+      message: `Abhängigkeit angelegt: ${parsed.data.type}${parsed.data.lagDays ? ' Lag ' + parsed.data.lagDays + 'd' : ''}`,
+      refTable: 'task_dependencies',
+      refId: row.id
+    });
+    return { ok: true, depId: row.id };
+  },
+
+  updateDep: async ({ request, params, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const schema = z.object({
+      depId: z.string().uuid(),
+      type: z.enum(['FS', 'SS', 'FF', 'SF']),
+      lagDays: z.coerce.number().int().min(-365).max(365)
+    });
+    const parsed = schema.safeParse(fd);
+    if (!parsed.success) return fail(400);
+
+    // RLS schützt: nur deps deren tasks im Projekt sind sind sichtbar
+    const dep = await db
+      .select({ predecessorId: taskDependencies.predecessorId })
+      .from(taskDependencies)
+      .where(eq(taskDependencies.id, parsed.data.depId))
+      .limit(1);
+    if (dep.length === 0) return fail(404);
+
+    await db
+      .update(taskDependencies)
+      .set({ type: parsed.data.type, lagDays: parsed.data.lagDays })
+      .where(eq(taskDependencies.id, parsed.data.depId));
+    return { ok: true };
+  },
+
+  deleteDep: async ({ request, params, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const schema = z.object({ depId: z.string().uuid() });
+    const parsed = schema.safeParse(fd);
+    if (!parsed.success) return fail(400);
+
+    await db.delete(taskDependencies).where(eq(taskDependencies.id, parsed.data.depId));
+    return { ok: true };
   }
 };

--- a/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Gantt from '$lib/components/Gantt.svelte';
+  import Gantt, { type Dependency } from '$lib/components/Gantt.svelte';
   import Icon from '$lib/components/Icon.svelte';
   import { enhance } from '$app/forms';
   import { invalidateAll, goto } from '$app/navigation';
@@ -126,6 +126,59 @@
 
   type DiffRow = { id: string; name: string; num: string | null; oldStart: string; oldEnd: string; newStart: string; newEnd: string };
   let pendingMove = $state<null | { taskId: string; newStart: string; newEnd: string; diff: DiffRow[] }>(null);
+
+  /* ===== Dependency-CRUD (PR #8) ===== */
+  let depPopover = $state<Dependency | null>(null);
+
+  async function createDep(predId: string, succId: string, predHandle: 'start' | 'end', succHandle: 'start' | 'end') {
+    // Map handle-pair to type: pred=end + succ=start = FS, pred=start + succ=start = SS,
+    // pred=end + succ=end = FF, pred=start + succ=end = SF
+    let type: 'FS' | 'SS' | 'FF' | 'SF';
+    if (predHandle === 'end' && succHandle === 'start') type = 'FS';
+    else if (predHandle === 'start' && succHandle === 'start') type = 'SS';
+    else if (predHandle === 'end' && succHandle === 'end') type = 'FF';
+    else type = 'SF';
+
+    const fd = new FormData();
+    fd.append('predecessorId', predId);
+    fd.append('successorId', succId);
+    fd.append('type', type);
+    fd.append('lagDays', '0');
+    const res = await fetch('?/createDep', { method: 'POST', body: fd });
+    if (res.ok) {
+      toast(`Abhängigkeit angelegt (${type}).`);
+      await invalidateAll();
+    } else {
+      toast('Anlage fehlgeschlagen.');
+    }
+  }
+
+  async function saveDepEdit(type: Dependency['type'], lagDays: number) {
+    if (!depPopover) return;
+    const fd = new FormData();
+    fd.append('depId', depPopover.id);
+    fd.append('type', type);
+    fd.append('lagDays', String(lagDays));
+    const res = await fetch('?/updateDep', { method: 'POST', body: fd });
+    if (res.ok) {
+      toast('Abhängigkeit aktualisiert.');
+      depPopover = null;
+      await invalidateAll();
+    }
+  }
+
+  async function deleteDep() {
+    if (!depPopover) return;
+    if (!confirm('Abhängigkeit löschen?')) return;
+    const fd = new FormData();
+    fd.append('depId', depPopover.id);
+    const res = await fetch('?/deleteDep', { method: 'POST', body: fd });
+    if (res.ok) {
+      toast('Gelöscht.');
+      depPopover = null;
+      await invalidateAll();
+    }
+  }
 
   async function previewMove(taskId: string, newStart: string, newEnd: string) {
     const fd = new FormData();
@@ -285,9 +338,12 @@
     </div>
     <Gantt
       tasks={visibleTasks}
+      dependencies={parent.deps as Dependency[]}
       criticalPathIds={cpIds}
       onSelect={(id) => (selected = id)}
       onMove={previewMove}
+      onDepCreate={createDep}
+      onDepClick={(id) => (depPopover = parent.deps.find((d) => d.id === id) ?? null)}
       baseline={activeBaseline}
       lookaheadWeeks={lookahead}
     />
@@ -362,6 +418,39 @@
     </div>
     <div class="sheet-foot">
       <button class="btn btn-ghost btn-block" onclick={() => (selected = null)}>Schließen</button>
+    </div>
+  </div>
+{/if}
+
+{#if depPopover}
+  <button class="scrim open" onclick={() => (depPopover = null)} aria-label="Schließen"></button>
+  <div class="dialog open" role="dialog" aria-label="Abhängigkeit bearbeiten" style="display:flex">
+    <div class="dialog-panel">
+      <h3 class="dialog-title">Abhängigkeit bearbeiten</h3>
+      <p class="dialog-text">
+        {depPopover.type} · Lag {depPopover.lagDays}d
+      </p>
+      <div class="field">
+        <label class="field-label" for="dep-type">Typ</label>
+        <select id="dep-type" class="field-input" bind:value={depPopover.type}>
+          <option value="FS">FS — Finish-to-Start (Standard)</option>
+          <option value="SS">SS — Start-to-Start</option>
+          <option value="FF">FF — Finish-to-Finish</option>
+          <option value="SF">SF — Start-to-Finish</option>
+        </select>
+      </div>
+      <div class="field">
+        <label class="field-label" for="dep-lag">Lag in Arbeitstagen (negativ = Lead)</label>
+        <input id="dep-lag" type="number" class="field-input" bind:value={depPopover.lagDays} min="-365" max="365" />
+      </div>
+      <div class="dialog-actions">
+        <button class="btn btn-danger" onclick={deleteDep}>
+          <Icon name="delete" size={14} /> Löschen
+        </button>
+        <span style="flex:1"></span>
+        <button class="btn btn-ghost" onclick={() => (depPopover = null)}>Abbrechen</button>
+        <button class="btn btn-primary" onclick={() => saveDepEdit(depPopover!.type, depPopover!.lagDays)}>Speichern</button>
+      </div>
     </div>
   </div>
 {/if}


### PR DESCRIPTION
## Was es macht

Drag&Drop-Dependencies wie in MS Project. Hover über eine Gantt-Bar zeigt
zwei kleine Connector-Handles (links = Start, rechts = Ende). Drag von einem
Handle zu einer anderen Bar erzeugt eine Dependency. Die Pred-Handle/
Succ-Handle-Kombination bestimmt den Typ:

| Pred-Handle | Succ-Handle | Typ |
|---|---|---|
| Ende | Start | **FS** (Standard) |
| Start | Start | **SS** |
| Ende | Ende | **FF** |
| Start | Ende | **SF** |

Pfeile rendern als SVG-Polylinien zwischen den Bars (rechtwinklig, mit
10px-Stub vom Edge, vertikal in die Ziel-Bar-Höhe, dann zum Succ-Edge).
`<marker>` zeichnet die Pfeilspitze. Hover-State färbt den Pfeil rot
(`pointer-events: stroke` macht ihn selber klickbar).

Click auf einen Pfeil öffnet einen **Edit-Dialog**: Typ-Select (4
Optionen), Lag-Days-Input (negativ erlaubt = Lead), Löschen-Button.

## Mobile-Fallback (kein präzises Drag)

Auf Touch ist Hover irrelevant — die Handles sind permanent leicht
sichtbar (`opacity: 0.55`). **Right-click (Desktop) oder Long-press
(Mobile)** auf einem Handle aktiviert den **Connector-Mode**: ein
Bottom-Banner zeigt „Tippe auf eine Bar zum Verbinden", der nächste Tap
auf eine andere Bar erzeugt die Dep (Standard FS, kann nachträglich im
Edit-Dialog umgestellt werden).

## Server-Actions (alle in `+page.server.ts`)

```
?/createDep    pred + succ + type + lagDays
?/updateDep    depId + type + lagDays
?/deleteDep    depId
```

Mit Zod-Validation. `createDep` prüft Defense-in-Depth, dass beide Tasks
im selben Projekt sind (RLS plus expliziter Check). Idempotent: Duplikat
(pred+succ existiert) wird zu Update statt Insert.

## Constraint-Propagation bleibt aktiv

Die existierende `propagate()`-Engine liest `parent.deps`. Wenn nach dem
Anlegen einer Dependency der Bauleiter eine der Tasks verschiebt, kommt
der bestehende Diff-Dialog mit den neu betroffenen Folge-Tasks. Kein
zusätzlicher Re-Schedule-Trigger nötig — `invalidateAll()` lädt die deps
mit, die nächste Drag-Aktion nutzt sie.

## Performance-Annahme

Mit 150 Termine (Gaisbach 13) habe ich es nicht live gemessen — der
SVG-Pfad-Render ist O(n) pro Frame, und 150 Pfade sind weit unter dem
Browser-Renderlimit. Lokal habe ich es mit gestickten Browser-Profile
nicht profiled (Stop-Condition wäre nur "kann ich nicht erreichen"). Im
PR-Test-Plan ist der Performance-Check aufgeführt.

## Keine Migration nötig

`task_dependencies` existiert seit `0000`. Spalten `type` (text-enum
FS/SS/FF/SF) und `lag_days` (int default 0) sind schon da.

## Self-Review

- [x] Kein `console.log` / TODO / FIXME
- [x] Edge-Case: leere `dependencies[]` → SVG wird gar nicht gerendert
- [x] Edge-Case: pred = succ → server-action returnt 400
- [x] Edge-Case: Tasks aus anderem Projekt → server-action returnt 403
- [x] Edge-Case: Duplikat-Insert → wird zu Update (idempotent)
- [x] Mobile: Long-press / right-click + Connector-Mode + Banner
- [x] Reduced-motion: dep-mode-target Pulsanimation respektiert `prefers-reduced-motion`
- [x] Realtime: noop — `parent.deps` kommt aus dem Server-Load und wird via `invalidateAll` aktualisiert; Realtime-Subscription auf `task_dependencies` könnte später ergänzt werden
- [x] type-check 0 errors, tests 15/15, build OK
- [x] Diff: 5 files, 489 LoC (knapp unter 500)
- [x] Keine Migration

## Test plan (Self-Merge nach Vercel-Preview-Ready)

- [x] `pnpm check` → 0 errors
- [x] `pnpm test` → 15/15 grün
- [x] `pnpm build` → OK
- [ ] Live nach Merge:
  - [ ] Desktop: hover über Bar zeigt 2 weiße Handles
  - [ ] Drag von Ende-Handle zur nächsten Bar → Pfeil erscheint, FS angelegt
  - [ ] Drag mit anderen Handle-Kombinationen → SS/FF/SF korrekt
  - [ ] Click auf Pfeil → Edit-Dialog, Typ ändern + Lag setzen → Pfeil rerenders
  - [ ] Löschen via Dialog → Pfeil weg
  - [ ] Mobile (375px): right-click oder long-press auf Handle → Banner unten,
        Tap auf Ziel-Bar → Pfeil erscheint
  - [ ] Termin nach Anlegen einer Dep verschieben → propagate() kaskadiert
        wie vorher
  - [ ] Performance: 150-Tasks-Projekt, Drag-Frame-Rate gefühlt > 30fps

## Self-Merge

Bedingungen erfüllt (keine Migration, Diff knapp unter 500 LoC, isoliert,
alle Checks grün). Merge nach Vercel-Preview-Ready selbst durchführen.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_