### PR TITLE
feat(ux/empty-states): EmptyState component + kontextspezifische States

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,17 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 
 ---
 
-## [unreleased] — 2026-04-30 (post-rc2)
+## [unreleased] — post-rc2
+
+### Added
+- feat(ux/empty-states): `EmptyState.svelte`-Komponente ersetzt das alte
+  „·"-Emoji + grauer Text. Drei Varianten (default/success/info), optionaler
+  CTA-Slot, kompakter Modus für Inline-Verwendung. Eingebaut in:
+  - **Aufgaben**: kontextspezifische Texte pro Filter
+    („Nichts überfällig" / „Heute frei" / „Diese Woche entspannt" / „Alles im Plan")
+  - **Mängel**: Onboarding-CTA „Ersten Mangel anlegen" wenn noch nichts da ist,
+    sonst „Keine Treffer im Filter" mit Reset-Hint
+  Sehr kleines Diff (3 Files), klare visuelle Aufwertung. (PR #9)
 
 ### Fixed
 - `GET /<projectId>/checklisten` warf 500 mit

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,8 +1,15 @@
 # PROGRESS
 
-**Hotfix post-rc2** (2026-04-30): `/checklisten` 500er behoben — falsche
-FROM-clause in 2 Aggregat-Queries (`listChecklistsWithProgress`).
-PR-Body: siehe `claude/fix-checklisten-from-clause`.
+**post-rc2 Session** (heute):
+- PR #5 (gemerged): /checklisten FROM-clause-Fix
+- PR #6 (offen, CI-Re-Run nötig): /checklisten/[id] empty-progress IN()-Fix
+- PR #7 (offen, **Migration 0007**): Plan-Crop für Mängel
+- PR #8 (offen, KEINE Migration): Gantt-Drag&Drop-Dependencies
+- PR #9 (offen): Design-Politur — EmptyState-Komponente, kontextspezifische
+  Empty-States in Aufgaben + Mängel
+
+Als Nächstes: PR #10 (Musterdetails-Modul), PR #11 (QR-Freimeldung),
+PR #12 (Portfolio-Dashboard).
 
 **BUILD COMPLETE v1.0.0-rc2** — Migration-Fix, Premium-UX, DocMa-Features, Deploy-Ready.
 

--- a/src/lib/components/EmptyState.svelte
+++ b/src/lib/components/EmptyState.svelte
@@ -1,0 +1,95 @@
+<script lang="ts" module>
+  export type EmptyVariant = 'default' | 'success' | 'info';
+</script>
+
+<script lang="ts">
+  /**
+   * Polished Empty-State (ersetzt das alte „·"-Emoji + grauer Text).
+   *
+   * - Variant `default`: neutrale grau-getönte Karte
+   * - Variant `success`: grüner Tint, geeignet für „Alles erledigt"
+   * - Variant `info`: blaue Akzentfarbe, geeignet für Onboarding-Hint
+   *
+   * Slots: `cta` für eine optionale Action (z.B. „Ersten Mangel anlegen")
+   */
+  import type { Snippet } from 'svelte';
+  import type { IconName } from './Icon.svelte';
+  import Icon from './Icon.svelte';
+
+  type Props = {
+    title: string;
+    description?: string;
+    icon?: IconName;
+    variant?: EmptyVariant;
+    cta?: Snippet;
+    compact?: boolean;
+  };
+  let { title, description, icon = 'check', variant = 'default', cta, compact = false }: Props = $props();
+</script>
+
+<div class="empty-state empty-{variant}" class:compact>
+  <div class="empty-icon" aria-hidden="true">
+    <Icon name={icon} size={compact ? 16 : 22} />
+  </div>
+  <div class="empty-text-wrap">
+    <p class="empty-title">{title}</p>
+    {#if description}<p class="empty-description">{description}</p>{/if}
+  </div>
+  {#if cta}<div class="empty-cta">{@render cta()}</div>{/if}
+</div>
+
+<style>
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 32px 20px;
+    background: var(--paper);
+    border: 1px solid var(--line);
+    border-radius: var(--r-lg, 14px);
+    text-align: center;
+  }
+  .empty-state.compact {
+    flex-direction: row;
+    padding: 12px 14px;
+    gap: 10px;
+    text-align: left;
+    align-items: center;
+  }
+  .empty-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: var(--paper-tint);
+    color: var(--muted);
+    flex-shrink: 0;
+  }
+  .empty-state.compact .empty-icon { width: 28px; height: 28px; border-radius: 8px; }
+
+  /* Variants */
+  .empty-success .empty-icon { background: var(--green-soft); color: var(--green); }
+  .empty-info .empty-icon { background: var(--blue-soft); color: var(--blue); }
+
+  .empty-text-wrap { display: flex; flex-direction: column; gap: 3px; flex: 1; min-width: 0; }
+  .empty-title {
+    margin: 0;
+    font-family: var(--display);
+    font-weight: 700;
+    font-size: 14px;
+    color: var(--ink);
+  }
+  .empty-state.compact .empty-title { font-size: 13px; }
+  .empty-description {
+    margin: 0;
+    color: var(--muted);
+    font-size: 13px;
+    line-height: 1.4;
+  }
+  .empty-state.compact .empty-description { font-size: 12px; }
+  .empty-cta { margin-top: 4px; }
+  .empty-state.compact .empty-cta { margin-top: 0; }
+</style>

--- a/src/routes/(app)/[projectId]/aufgaben/+page.svelte
+++ b/src/routes/(app)/[projectId]/aufgaben/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Icon from '$lib/components/Icon.svelte';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import { fmtDateDe } from '$lib/util/time';
   import type { AufgabeRow } from './+page.server';
 
@@ -81,10 +82,35 @@
   </div>
 
   {#if visible.length === 0}
-    <div class="empty">
-      <div class="empty-emoji">·</div>
-      <div class="empty-text">Alles im Plan.</div>
-    </div>
+    {#if filter === 'ueberfaellig'}
+      <EmptyState
+        variant="success"
+        icon="check"
+        title="Nichts überfällig."
+        description="Alle Termine und Mängel laufen im Zeitplan."
+      />
+    {:else if filter === 'heute'}
+      <EmptyState
+        variant="success"
+        icon="check"
+        title="Heute frei."
+        description="Keine Aufgaben für heute fällig."
+      />
+    {:else if filter === 'woche'}
+      <EmptyState
+        variant="success"
+        icon="calendar"
+        title="Diese Woche entspannt."
+        description="Keine Aufgaben in den nächsten 7 Tagen fällig."
+      />
+    {:else}
+      <EmptyState
+        variant="success"
+        icon="check"
+        title="Alles im Plan."
+        description="Sobald Termine oder Mängel mit Deadline anstehen, tauchen sie hier auf."
+      />
+    {/if}
   {:else}
     {#each ['ueberfaellig', 'woche', 'kommend', 'spaeter'] as group}
       {#if grouped[group].length > 0}

--- a/src/routes/(app)/[projectId]/maengel/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Icon from '$lib/components/Icon.svelte';
+  import EmptyState from '$lib/components/EmptyState.svelte';
   import DraftPhotoStrip, { type DraftPhoto } from '$lib/components/DraftPhotoStrip.svelte';
   import { fmtDateDe } from '$lib/util/time';
   import { invalidateAll } from '$app/navigation';
@@ -140,10 +141,27 @@
   </div>
 
   {#if visible.length === 0}
-    <div class="empty">
-      <div class="empty-emoji">·</div>
-      <div class="empty-text">Keine Mängel in diesem Filter.</div>
-    </div>
+    {#if parent.defects.length === 0}
+      <EmptyState
+        variant="info"
+        icon="defect"
+        title="Noch keine Mängel."
+        description="Lege den ersten Mangel an oder importiere mehrere Zeilen aus einem Protokoll-Text."
+      >
+        {#snippet cta()}
+          <button class="btn btn-primary btn-sm" onclick={() => (showCreate = true)}>
+            <Icon name="plus" size={14} /> Ersten Mangel anlegen
+          </button>
+        {/snippet}
+      </EmptyState>
+    {:else}
+      <EmptyState
+        variant="default"
+        icon="list"
+        title="Keine Treffer im Filter."
+        description="Setze die Filter zurück, um alle {parent.defects.length} Mängel zu sehen."
+      />
+    {/if}
   {:else}
     {#each [['open','Offen'],['reopened','Wiedereröffnet'],['sent','Gesendet'],['acknowledged','Bestätigt'],['resolved','Erledigt'],['accepted','Akzeptiert'],['rejected','Abgelehnt']] as [grpStatus, grpLabel]}
       {@const grp = visible.filter((d) => d.status === grpStatus)}


### PR DESCRIPTION
## Was es macht

Erste Iteration der Design-Politur. Klein gehalten — ein **sichtbarer
Hebel** statt globalen Refactor. Das alte `·`-Emoji + grauer Text wird
durch eine aufgeräumte `EmptyState.svelte`-Komponente ersetzt.

## Komponente

`src/lib/components/EmptyState.svelte` (neu):
- 3 Varianten: `default` (neutral), `success` (grün, „alles erledigt"),
  `info` (blau, Onboarding)
- Optionaler CTA-Slot für Action-Buttons
- `compact`-Modus für Inline-Verwendung in Listen-Sektionen
- Title + optionale Description unter Icon-Tile

## Eingebaut in

**Aufgaben-Tab**: kontextspezifische Texte je nach Filter:
| Filter | Empty-Title | Variant | Icon |
|---|---|---|---|
| `ueberfaellig` | „Nichts überfällig." | success | check |
| `heute` | „Heute frei." | success | check |
| `woche` | „Diese Woche entspannt." | success | calendar |
| (Default) | „Alles im Plan." | success | check |

**Mängel-Liste**: zwei verschiedene Empty-States:
- Wenn `parent.defects.length === 0` (Projekt komplett leer):
  → `info`-Variant mit CTA-Button **„Ersten Mangel anlegen"**
- Wenn nur die Filter zu strikt sind:
  → `default`-Variant mit Hint „Setze die Filter zurück, um alle X Mängel zu sehen"

## Stitch-Status

Der Master-Prompt sagt: „Prüfen ob `mcp__stitch__*` Tools verfügbar
sind". Antwort: **Nein** — in der aktuellen Session sind keine
Stitch-MCP-Tools über `system-reminder` angekündigt worden. Der von
dir geteilte `claude mcp add stitch …`-Befehl konfiguriert deine
lokale CLI, nicht diese Session. Deshalb der „self-do"-Pfad mit
fokussierter Komponente statt vollem Mock-Workflow.

Wenn du mir in einer späteren Session Stitch-Mocks unter
`docs/design-mocks/` ablegst, kann ich gegen die polishen.

## Self-Review

- [x] Kein `console.log` / TODO / FIXME
- [x] Reusable & isoliert in eigener Komponente
- [x] Mobile: 44px+ Touch-Targets (CTA-Button btn-sm = 36px → noch ok als Sekundär-Action; primärer Aufgaben-Tab hat eigene Bottom-Tabbar)
- [x] Reduced-motion: keine Animationen, also irrelevant
- [x] type-check 0, tests 15/15, build OK
- [x] Diff: 5 Files, 168 LoC
- [x] Keine Migrations

## Test plan

- [x] `pnpm check` → 0 errors
- [x] `pnpm test` → 15/15 grün
- [x] `pnpm build` → OK
- [ ] Live nach Merge:
  - [ ] Neues Projekt → Mängel-Tab → Onboarding-Card mit CTA „Ersten Mangel anlegen"
  - [ ] Mangel anlegen → Card verschwindet
  - [ ] Filter „Erledigt" auf leerem Status → „Keine Treffer im Filter"-Card
  - [ ] Aufgaben-Filter „Überfällig" wenn leer → „Nichts überfällig" success-Card

## Out-of-scope (Phase 5+)

- Empty-States in `/checklisten/[id]` (gut versteckt, low priority)
- Loading-Skeletons für die Hauptlisten — hatte ich `Skeleton.svelte` schon
  in rc2, ist verfügbar aber noch nicht überall eingebaut. Nächste UX-PR.
- Error-Boundaries mit Retry-Button — fängt heute toast-only

## Self-Merge

Bedingungen erfüllt (keine Migration, kleines isoliertes Diff,
alle Checks grün). Nach Vercel-Preview-Ready selbst mergen.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_