### PR TITLE
fix(ci): pnpm version conflict (5s build failure)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm before setup-node so 'cache: pnpm' below can find it on PATH.
+      # No `version` here — pnpm/action-setup reads `packageManager` from
+      # package.json (pnpm@9.12.0). Specifying both leads to "Multiple
+      # versions of pnpm specified" which fails in <5s (the bug we hit).
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile=false
+      - run: pnpm install --no-frozen-lockfile
 
       - name: Type check
         run: pnpm check


### PR DESCRIPTION
## Stop-the-bleed

CI Build-Job stirbt seit gestern Nacht nach 5 Sekunden — vor jedem
echten Step. Selbst-merge ist deshalb für alle PRs blockiert.

## Diagnose

`pnpm/action-setup@v4` hatte explizit `version: 9`, während `package.json`
gleichzeitig `packageManager: "pnpm@9.12.0"` setzt. Die Action erkennt
den Konflikt („Multiple versions of pnpm specified") und exit 1, bevor
auch nur `actions/setup-node` läuft.

## Fix (3 Zeilen)

```diff
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
+        # version aus packageManager-field statt explizit
```

Plus kosmetisch: `pnpm install --frozen-lockfile=false` → `--no-frozen-lockfile`.

## Test plan

- [x] `pnpm check` → 0 errors
- [x] `pnpm test` → 15/15 grün
- [x] `pnpm build` → OK
- [ ] Auf PR-Run: 3 Schritte (install/check/test/build) durchlaufen ohne
      „Multiple versions of pnpm" — erwartete Run-Dauer ~80-120s statt 5s

## Self-Merge

Reine Workflow-Datei, keine Code/Migration. Self-Merge sobald **dieser**
Run grün durchläuft (Henne-Ei-Auflösung: der Workflow-Fix muss sich
selber bestätigen).

Wenn das passiert: weiter mit PR #6 → #8 → #9.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_