### PR TITLE
feat(ux/confirm-dialog): replace native confirm() with Sheet-based dialog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 ## [unreleased] — post-rc2
 
 ### Added
+- feat(ux/confirm-dialog): `ConfirmDialog.svelte` ersetzt das native
+  `window.confirm()` durch einen Sheet-basierten Dialog mit imperativer
+  `await confirm({title, description?, confirmLabel?, danger?})`-API.
+  Mobile-friendly (44px+ Touch-Targets), haptic-feedback bei Bestätigung,
+  ESC + Drag-to-close. Eingebaut in 6 destruktiven Aktionen
+  (Foto-Löschen × 2, Termin-Löschen, Kontakt-Löschen, Musterdetail-Löschen,
+  Dependency-Löschen). Fallback auf `window.confirm` wenn Host nicht
+  gemounted ist (z.B. SSR/Tests). (PR #12)
 - feat(bauzeit/deps): Drag&Drop-Dependencies wie in MS-Project. Hover-
   Handles auf jeder Bar (Start + Ende), Drag von einem Handle zu einer
   anderen Bar erzeugt Abhängigkeit (Pred-Handle × Succ-Handle bestimmt

--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -1,0 +1,94 @@
+<script lang="ts" module>
+  type Resolver = (ok: boolean) => void;
+  type Opts = {
+    title: string;
+    description?: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    danger?: boolean;
+  };
+
+  let setOpen: ((opts: Opts, resolve: Resolver) => void) | null = null;
+
+  /**
+   * Imperative confirm dialog. Returns Promise<boolean>.
+   * Replaces window.confirm() with a Sheet-based, mobile-friendly dialog.
+   *
+   *   if (!(await confirm({ title: 'Foto löschen?', danger: true }))) return;
+   */
+  export function confirm(opts: Opts): Promise<boolean> {
+    return new Promise((resolve) => {
+      if (setOpen) setOpen(opts, resolve);
+      else resolve(window.confirm(opts.title));
+    });
+  }
+</script>
+
+<script lang="ts">
+  import Sheet from './Sheet.svelte';
+  import { haptic } from '$lib/motion';
+
+  let open = $state(false);
+  let title = $state('');
+  let description = $state<string | undefined>(undefined);
+  let confirmLabel = $state('OK');
+  let cancelLabel = $state('Abbrechen');
+  let danger = $state(false);
+  let pending = $state<Resolver | null>(null);
+
+  setOpen = (opts, resolve) => {
+    title = opts.title;
+    description = opts.description;
+    confirmLabel = opts.confirmLabel ?? 'OK';
+    cancelLabel = opts.cancelLabel ?? 'Abbrechen';
+    danger = opts.danger ?? false;
+    pending = resolve;
+    open = true;
+  };
+
+  function settle(ok: boolean) {
+    pending?.(ok);
+    pending = null;
+    open = false;
+    if (ok) haptic(10);
+  }
+
+  function onClose() {
+    if (pending) settle(false);
+  }
+</script>
+
+<Sheet bind:open ariaLabel={title} {onClose}>
+  {#snippet head()}
+    <h3 class="sheet-title">{title}</h3>
+    {#if description}<p class="confirm-desc">{description}</p>{/if}
+  {/snippet}
+  {#snippet foot()}
+    <div class="confirm-actions">
+      <button type="button" class="btn btn-ghost" onclick={() => settle(false)}>{cancelLabel}</button>
+      <button
+        type="button"
+        class="btn"
+        class:btn-danger={danger}
+        class:btn-primary={!danger}
+        onclick={() => settle(true)}
+      >{confirmLabel}</button>
+    </div>
+  {/snippet}
+</Sheet>
+
+<style>
+  .confirm-desc {
+    font-size: 14px;
+    color: var(--ink-2);
+    margin: 4px 0 0;
+    line-height: 1.4;
+  }
+  .confirm-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    padding: 4px 0;
+  }
+  .confirm-actions .btn { min-width: 96px; min-height: 44px; }
+</style>

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Toast from '$lib/components/Toast.svelte';
   import CommandPalette from '$lib/components/CommandPalette.svelte';
+  import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 
   let { children } = $props();
 </script>
@@ -8,3 +9,4 @@
 {@render children()}
 <Toast />
 <CommandPalette />
+<ConfirmDialog />

--- a/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
@@ -6,6 +6,7 @@
   import { page } from '$app/state';
   import { criticalPath, type EngineTask, type EngineDep } from '$lib/gantt/engine';
   import { toast } from '$lib/components/Toast.svelte';
+  import { confirm } from '$lib/components/ConfirmDialog.svelte';
 
   let { data } = $props();
   let parent = $derived(data);
@@ -169,7 +170,7 @@
 
   async function deleteDep() {
     if (!depPopover) return;
-    if (!confirm('Abhängigkeit löschen?')) return;
+    if (!(await confirm({ title: 'Abhängigkeit löschen?', confirmLabel: 'Löschen', danger: true }))) return;
     const fd = new FormData();
     fd.append('depId', depPopover.id);
     const res = await fetch('?/deleteDep', { method: 'POST', body: fd });

--- a/src/routes/(app)/[projectId]/bauzeitenplan/[taskId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/[taskId]/+page.svelte
@@ -2,6 +2,7 @@
   import { goto, invalidateAll } from '$app/navigation';
   import Icon from '$lib/components/Icon.svelte';
   import { toast } from '$lib/components/Toast.svelte';
+  import { confirm } from '$lib/components/ConfirmDialog.svelte';
   import { uploadTaskPhoto, getSignedUrl } from '$lib/storage/photos';
   import { haptic } from '$lib/motion';
 
@@ -55,7 +56,7 @@
   }
 
   async function delTaskPhoto(photoId: string) {
-    if (!confirm('Foto löschen?')) return;
+    if (!(await confirm({ title: 'Foto löschen?', confirmLabel: 'Löschen', danger: true }))) return;
     const fd = new FormData();
     fd.append('photoId', photoId);
     await fetch('?/deletePhoto', { method: 'POST', body: fd });
@@ -81,7 +82,7 @@
   }
 
   async function del() {
-    if (!confirm('Termin wirklich löschen?')) return;
+    if (!(await confirm({ title: 'Termin wirklich löschen?', description: 'Alle zugehörigen Daten gehen verloren.', confirmLabel: 'Löschen', danger: true }))) return;
     const ok = await postForm('delete', {});
     if (ok) {
       toast('Termin gelöscht.');

--- a/src/routes/(app)/[projectId]/kontakte/+page.svelte
+++ b/src/routes/(app)/[projectId]/kontakte/+page.svelte
@@ -2,6 +2,7 @@
   import Icon from '$lib/components/Icon.svelte';
   import { invalidateAll } from '$app/navigation';
   import { toast } from '$lib/components/Toast.svelte';
+  import { confirm } from '$lib/components/ConfirmDialog.svelte';
 
   let { data } = $props();
   let parent = $derived(data);
@@ -63,7 +64,7 @@
 
   async function del() {
     if (!editing?.id) return;
-    if (!confirm('Kontakt löschen?')) return;
+    if (!(await confirm({ title: 'Kontakt löschen?', confirmLabel: 'Löschen', danger: true }))) return;
     const fd = new FormData();
     fd.append('id', editing.id);
     const res = await fetch('?/delete', { method: 'POST', body: fd });

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
@@ -4,6 +4,7 @@
   import VoiceInput from '$lib/components/VoiceInput.svelte';
   import { uploadDefectPhoto, getSignedUrl } from '$lib/storage/photos';
   import { toast } from '$lib/components/Toast.svelte';
+  import { confirm } from '$lib/components/ConfirmDialog.svelte';
   import { invalidateAll } from '$app/navigation';
   import { fmtDateDe, timeAgo } from '$lib/util/time';
   import { haptic } from '$lib/motion';
@@ -80,7 +81,7 @@
   }
 
   async function delPhoto(photoId: string) {
-    if (!confirm('Foto löschen?')) return;
+    if (!(await confirm({ title: 'Foto löschen?', confirmLabel: 'Löschen', danger: true }))) return;
     await postForm('deletePhoto', { photoId });
     await invalidateAll();
   }

--- a/src/routes/(app)/[projectId]/musterdetails/+page.svelte
+++ b/src/routes/(app)/[projectId]/musterdetails/+page.svelte
@@ -3,6 +3,7 @@
   import { uploadMusterdetailImage } from '$lib/storage/photos';
   import { invalidateAll } from '$app/navigation';
   import { toast } from '$lib/components/Toast.svelte';
+  import { confirm } from '$lib/components/ConfirmDialog.svelte';
 
   let { data } = $props();
   let parent = $derived(data);
@@ -32,7 +33,7 @@
   }
 
   async function del(id: string) {
-    if (!confirm('Wirklich löschen?')) return;
+    if (!(await confirm({ title: 'Bild wirklich löschen?', confirmLabel: 'Löschen', danger: true }))) return;
     const fd = new FormData();
     fd.append('id', id);
     await fetch('?/delete', { method: 'POST', body: fd });


### PR DESCRIPTION
## Was es macht

Ersetzt das native `window.confirm()` durch einen Sheet-basierten,
mobile-friendly Confirm-Dialog. Imperative API:

```ts
import { confirm } from '$lib/components/ConfirmDialog.svelte';

if (!(await confirm({
  title: 'Foto löschen?',
  confirmLabel: 'Löschen',
  danger: true
}))) return;
```

`ConfirmDialog.svelte` wird als Singleton in `(app)/+layout.svelte`
gemounted und kommuniziert über eine module-scoped `setOpen`-Variable
(gleicher Pattern wie `Toast.toast()`).

## Eingebaut in

6 destruktive Aktionen:

| Datei | Aktion |
|---|---|
| `maengel/[defectId]/+page.svelte` | Foto löschen |
| `bauzeitenplan/[taskId]/+page.svelte` | Foto löschen |
| `bauzeitenplan/[taskId]/+page.svelte` | Termin wirklich löschen (mit Description) |
| `bauzeitenplan/+page.svelte` | Abhängigkeit löschen |
| `kontakte/+page.svelte` | Kontakt löschen |
| `musterdetails/+page.svelte` | Bild löschen |

## Properties

- `title` (required): Dialog-Titel
- `description` (optional): Erklär-Text unter Titel
- `confirmLabel` (default `OK`): Text des Confirm-Buttons
- `cancelLabel` (default `Abbrechen`): Text des Cancel-Buttons
- `danger` (default `false`): rot styled Confirm-Button (für destruktive Aktionen)

## SSR-Safe

Wenn `setOpen` noch nicht gesetzt ist (SSR oder Tests ohne Layout-Mount),
fällt `confirm()` auf `window.confirm()` zurück. Kein `undefined`-Throw.

## Mobile-First

- Sheet (Bottom-Sheet) statt Center-Modal — passt zur App-Architektur
- 44px+ Touch-Targets auf Buttons
- Drag-to-close + ESC-Close (vom Sheet geerbt)
- Haptic-Feedback (10ms) bei Confirm

## Self-Review

- [x] Kein `console.log` / TODO / FIXME
- [x] Edge-Case: Cancel oder Drag-to-close → resolved mit `false`
- [x] Edge-Case: SSR ohne Mount → fällt auf `window.confirm` zurück
- [x] Reduced-motion: Sheet respektiert `prefers-reduced-motion` (vom Sheet geerbt)
- [x] type-check 0 errors
- [x] Vitest 17/17 grün
- [x] Build clean (@sveltejs/adapter-vercel OK)
- [x] Diff: 8 Files (1 neu + 1 layout + 5 Konsumenten + 1 CHANGELOG), 121 LoC
- [x] Keine Migration

## Test plan

- [x] `pnpm check` → 0 errors
- [x] `pnpm test` → 17/17 grün
- [x] `pnpm build` → OK
- [ ] Live nach Merge:
  - [ ] Mängel-Foto-Lösch-Button → Sheet erscheint, „Löschen" rot
  - [ ] Cancel oder Drag-down → Foto bleibt
  - [ ] Confirm → Foto weg, Toast „Gelöscht"
  - [ ] Termin löschen → Sheet mit Description „Alle zugehörigen Daten gehen verloren"
  - [ ] Mobile: Touch-Targets fühlen sich groß an

## Self-Merge

Bedingungen erfüllt (keine Migration, ~120 LoC, isoliert, alle Checks
grün). Self-Merge nach Vercel-Preview-Ready.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_