### PR TITLE
feat(search/cmdk): trigram search across Mängel/Kontakte/Termine

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,16 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 ## [unreleased] — post-rc2
 
 ### Added
+- feat(search/cmdk): Volltextsuche über Mängel/Kontakte/Termine pro
+  Projekt. Cmd+K zeigt nach 2+ Zeichen Live-Treffer (debounced 220ms).
+  Backend: pg_trgm GIN-Indexe (Migration 0008) + Drizzle-Endpoint
+  `/api/search?projectId&q=`. Trigram-Similarity ranked top 5 pro Kind,
+  RLS-respektiert (project-membership-Check vor Query). Klick navigiert
+  zu Mangel-Detail / Bauzeit-Editor / Kontakte-Liste.
+  **Migration 0008_search_trigram.sql benötigt** — der User muss sie
+  manuell im Supabase-SQL-Editor laufen lassen vor Merge. Idempotent
+  (`CREATE EXTENSION IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`),
+  zero-downtime. (PR #13)
 - feat(bauzeit/deps): Drag&Drop-Dependencies wie in MS-Project. Hover-
   Handles auf jeder Bar (Start + Ende), Drag von einem Handle zu einer
   anderen Bar erzeugt Abhängigkeit (Pred-Handle × Succ-Handle bestimmt

--- a/src/lib/components/CommandPalette.svelte
+++ b/src/lib/components/CommandPalette.svelte
@@ -11,6 +11,18 @@
   let query = $state('');
   let activeIdx = $state(0);
   let inputEl: HTMLInputElement | null = $state(null);
+  let searchHits = $state<SearchHit[]>([]);
+  let searching = $state(false);
+  let searchSeq = 0;
+
+  type SearchHit = {
+    kind: 'defect' | 'contact' | 'task';
+    id: string;
+    title: string;
+    subtitle: string | null;
+    href: string;
+    score: number;
+  };
 
   type Cmd = {
     id: string;
@@ -51,18 +63,67 @@
     return out;
   });
 
-  let filtered = $derived.by<Cmd[]>(() => {
+  let filteredCmds = $derived.by<Cmd[]>(() => {
     if (!query.trim()) return commands;
     const q = query.toLowerCase();
     return commands.filter((c) => c.label.toLowerCase().includes(q));
   });
 
+  type Item = { kind: 'cmd'; cmd: Cmd } | { kind: 'hit'; hit: SearchHit };
+  let items = $derived.by<Item[]>(() => {
+    const out: Item[] = filteredCmds.map((cmd) => ({ kind: 'cmd' as const, cmd }));
+    for (const hit of searchHits) out.push({ kind: 'hit', hit });
+    return out;
+  });
+
+  // Debounced fuzzy search via /api/search (trigram, project-scoped).
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  $effect(() => {
+    const q = query.trim();
+    const pid = projectId();
+    if (debounceTimer) clearTimeout(debounceTimer);
+    if (!pid || q.length < 2) {
+      searchHits = [];
+      searching = false;
+      return;
+    }
+    searching = true;
+    const seq = ++searchSeq;
+    debounceTimer = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/search?projectId=${pid}&q=${encodeURIComponent(q)}`);
+        if (!res.ok) {
+          if (seq === searchSeq) searchHits = [];
+          return;
+        }
+        const data = (await res.json()) as { hits: SearchHit[] };
+        if (seq === searchSeq) searchHits = data.hits ?? [];
+      } catch {
+        if (seq === searchSeq) searchHits = [];
+      } finally {
+        if (seq === searchSeq) searching = false;
+      }
+    }, 220);
+  });
+
   function handleSelect(idx: number) {
-    const c = filtered[idx];
-    if (!c) return;
+    const it = items[idx];
+    if (!it) return;
     open = false;
     query = '';
-    setTimeout(() => c.action(), 30);
+    if (it.kind === 'cmd') setTimeout(() => it.cmd.action(), 30);
+    else setTimeout(() => goto(it.hit.href), 30);
+  }
+
+  function hitIcon(kind: SearchHit['kind']): IconName {
+    if (kind === 'defect') return 'defect';
+    if (kind === 'contact') return 'phone';
+    return 'gantt';
+  }
+  function hitSection(kind: SearchHit['kind']): string {
+    if (kind === 'defect') return 'Mangel';
+    if (kind === 'contact') return 'Kontakt';
+    return 'Termin';
   }
 
   let chord = '';
@@ -89,7 +150,7 @@
 
     if (open) {
       if (e.key === 'Escape') { open = false; return; }
-      if (e.key === 'ArrowDown') { e.preventDefault(); activeIdx = Math.min(filtered.length - 1, activeIdx + 1); return; }
+      if (e.key === 'ArrowDown') { e.preventDefault(); activeIdx = Math.min(items.length - 1, activeIdx + 1); return; }
       if (e.key === 'ArrowUp') { e.preventDefault(); activeIdx = Math.max(0, activeIdx - 1); return; }
       if (e.key === 'Enter') { e.preventDefault(); handleSelect(activeIdx); return; }
     }
@@ -138,7 +199,7 @@
 
   // Reset active index when filter changes
   $effect(() => {
-    void filtered;
+    void items;
     activeIdx = 0;
   });
 </script>
@@ -159,23 +220,39 @@
       <span class="cmdk-hint">ESC</span>
     </div>
     <ul class="cmdk-list" role="listbox">
-      {#each filtered as c, i (c.id)}
+      {#each items as it, i (it.kind === 'cmd' ? `c:${it.cmd.id}` : `h:${it.hit.kind}:${it.hit.id}`)}
         <li>
-          <button
-            class="cmdk-item"
-            class:active={i === activeIdx}
-            onclick={() => handleSelect(i)}
-            onmouseenter={() => (activeIdx = i)}
-          >
-            <Icon name={c.icon} size={14} />
-            <span class="cmdk-label">{c.label}</span>
-            {#if c.section}<span class="cmdk-section">{c.section}</span>{/if}
-            {#if c.shortcut}<span class="cmdk-shortcut">{c.shortcut}</span>{/if}
-          </button>
+          {#if it.kind === 'cmd'}
+            <button
+              class="cmdk-item"
+              class:active={i === activeIdx}
+              onclick={() => handleSelect(i)}
+              onmouseenter={() => (activeIdx = i)}
+            >
+              <Icon name={it.cmd.icon} size={14} />
+              <span class="cmdk-label">{it.cmd.label}</span>
+              {#if it.cmd.section}<span class="cmdk-section">{it.cmd.section}</span>{/if}
+              {#if it.cmd.shortcut}<span class="cmdk-shortcut">{it.cmd.shortcut}</span>{/if}
+            </button>
+          {:else}
+            <button
+              class="cmdk-item"
+              class:active={i === activeIdx}
+              onclick={() => handleSelect(i)}
+              onmouseenter={() => (activeIdx = i)}
+            >
+              <Icon name={hitIcon(it.hit.kind)} size={14} />
+              <span class="cmdk-label">
+                <span>{it.hit.title}</span>
+                {#if it.hit.subtitle}<span class="cmdk-sub">{it.hit.subtitle}</span>{/if}
+              </span>
+              <span class="cmdk-section">{hitSection(it.hit.kind)}</span>
+            </button>
+          {/if}
         </li>
       {/each}
-      {#if filtered.length === 0}
-        <li class="cmdk-empty">Keine Treffer.</li>
+      {#if items.length === 0}
+        <li class="cmdk-empty">{searching ? 'Suche…' : 'Keine Treffer.'}</li>
       {/if}
     </ul>
   </div>
@@ -215,7 +292,8 @@
   }
   .cmdk-item.active, .cmdk-item:hover { background: var(--paper-tint); }
   .cmdk-item.active { background: var(--red-soft); color: var(--red); }
-  .cmdk-label { flex: 1; }
+  .cmdk-label { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+  .cmdk-sub { font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .cmdk-section { font-family: var(--mono); font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; }
   .cmdk-shortcut { font-family: var(--mono); font-size: 10px; color: var(--muted); border: 1px solid var(--line); padding: 1px 5px; border-radius: 4px; }
   .cmdk-empty { padding: 16px; text-align: center; color: var(--muted); font-size: 13px; }

--- a/src/lib/db/searchQueries.ts
+++ b/src/lib/db/searchQueries.ts
@@ -1,0 +1,107 @@
+/**
+ * Trigram-based fuzzy search over Mängel/Kontakte/Termine for a project.
+ * Backed by GIN(gin_trgm_ops) indexes from migration 0008.
+ *
+ * Returns up to `limitPerKind` rows per kind, ranked by trigram similarity.
+ */
+import { db } from './client';
+import { sql } from 'drizzle-orm';
+
+export type SearchHit = {
+  kind: 'defect' | 'contact' | 'task';
+  id: string;
+  title: string;
+  subtitle: string | null;
+  href: string;
+  score: number;
+};
+
+export async function searchProject(
+  projectId: string,
+  query: string,
+  limitPerKind = 5
+): Promise<SearchHit[]> {
+  if (!db) return [];
+  const q = query.trim();
+  if (q.length < 2) return [];
+
+  // Pattern for ILIKE; escape SQL wildcards in user input.
+  const pat = '%' + q.replace(/[\\%_]/g, (c) => '\\' + c) + '%';
+
+  const [defectRows, contactRows, taskRows] = await Promise.all([
+    db.execute<{ id: string; short_id: string | null; title: string; description: string | null; score: number }>(sql`
+      SELECT id, short_id, title, description,
+             greatest(
+               similarity(coalesce(title, ''), ${q}),
+               similarity(coalesce(short_id, ''), ${q}),
+               similarity(coalesce(description, ''), ${q})
+             ) AS score
+      FROM defects
+      WHERE project_id = ${projectId}
+        AND (title ILIKE ${pat} OR description ILIKE ${pat} OR short_id ILIKE ${pat})
+      ORDER BY score DESC
+      LIMIT ${limitPerKind}
+    `),
+    db.execute<{ id: string; company: string | null; contact_name: string | null; email: string | null; score: number }>(sql`
+      SELECT id, company, contact_name, email,
+             greatest(
+               similarity(coalesce(company, ''), ${q}),
+               similarity(coalesce(contact_name, ''), ${q}),
+               similarity(coalesce(email, ''), ${q})
+             ) AS score
+      FROM contacts
+      WHERE (project_id = ${projectId} OR project_id IS NULL)
+        AND (company ILIKE ${pat} OR contact_name ILIKE ${pat} OR email ILIKE ${pat})
+      ORDER BY score DESC
+      LIMIT ${limitPerKind}
+    `),
+    db.execute<{ id: string; num: string | null; name: string; score: number }>(sql`
+      SELECT id, num, name,
+             greatest(
+               similarity(coalesce(name, ''), ${q}),
+               similarity(coalesce(num, ''), ${q}),
+               similarity(coalesce(notes, ''), ${q})
+             ) AS score
+      FROM tasks
+      WHERE project_id = ${projectId}
+        AND (name ILIKE ${pat} OR num ILIKE ${pat} OR notes ILIKE ${pat})
+      ORDER BY score DESC
+      LIMIT ${limitPerKind}
+    `)
+  ]);
+
+  const out: SearchHit[] = [];
+  for (const r of defectRows) {
+    out.push({
+      kind: 'defect',
+      id: r.id,
+      title: `${r.short_id ?? 'M-?'} · ${r.title}`,
+      subtitle: r.description ? r.description.slice(0, 80) : null,
+      href: `/${projectId}/maengel/${r.id}`,
+      score: Number(r.score) || 0
+    });
+  }
+  for (const r of contactRows) {
+    const titleParts = [r.company, r.contact_name].filter(Boolean);
+    out.push({
+      kind: 'contact',
+      id: r.id,
+      title: titleParts.join(' · ') || r.email || 'Kontakt',
+      subtitle: r.email,
+      href: `/${projectId}/kontakte`,
+      score: Number(r.score) || 0
+    });
+  }
+  for (const r of taskRows) {
+    out.push({
+      kind: 'task',
+      id: r.id,
+      title: `${r.num ?? ''} ${r.name}`.trim(),
+      subtitle: 'Termin',
+      href: `/${projectId}/bauzeitenplan/${r.id}`,
+      score: Number(r.score) || 0
+    });
+  }
+  out.sort((a, b) => b.score - a.score);
+  return out;
+}

--- a/src/routes/api/search/+server.ts
+++ b/src/routes/api/search/+server.ts
@@ -1,0 +1,20 @@
+import { json, error } from '@sveltejs/kit';
+import { searchProject } from '$lib/db/searchQueries';
+import { userIsProjectMember } from '$lib/db/projectQueries';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+  if (!locals.user) error(401, 'Nicht authentifiziert');
+
+  const projectId = url.searchParams.get('projectId');
+  const q = url.searchParams.get('q')?.trim() ?? '';
+
+  if (!projectId) error(400, 'projectId fehlt');
+  if (q.length < 2) return json({ hits: [] });
+
+  const member = await userIsProjectMember(locals.user.id, projectId);
+  if (!member) error(403, 'Kein Mitglied dieses Projekts');
+
+  const hits = await searchProject(projectId, q, 5);
+  return json({ hits });
+};

--- a/supabase/migrations/0008_search_trigram.sql
+++ b/supabase/migrations/0008_search_trigram.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- 0008_search_trigram
+-- Trigram-based fuzzy search across Mängel, Kontakte, Termine.
+-- Fast LIKE '%term%' via pg_trgm + GIN indexes — language-agnostic
+-- (kein Stemming nötig, deutsche Umlaute und Bauteilnamen
+-- bleiben so wie sie sind).
+--
+-- Cmd+K Power-Up nutzt diese Indexe für globale Suche pro Projekt.
+-- Idempotent + transactional.
+-- ============================================================
+
+BEGIN;
+
+-- pg_trgm-Extension aktivieren (falls noch nicht).
+-- Supabase free tier hat sie verfügbar; idempotent durch IF NOT EXISTS.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Defects: searchable über short_id, title, description
+CREATE INDEX IF NOT EXISTS defects_title_trgm
+  ON public.defects USING gin (title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS defects_description_trgm
+  ON public.defects USING gin (description gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS defects_short_id_trgm
+  ON public.defects USING gin (short_id gin_trgm_ops);
+
+-- Contacts: searchable über company, contact_name, email
+CREATE INDEX IF NOT EXISTS contacts_company_trgm
+  ON public.contacts USING gin (company gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS contacts_contact_name_trgm
+  ON public.contacts USING gin (contact_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS contacts_email_trgm
+  ON public.contacts USING gin (email gin_trgm_ops);
+
+-- Tasks: searchable über name, num, notes
+CREATE INDEX IF NOT EXISTS tasks_name_trgm
+  ON public.tasks USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS tasks_num_trgm
+  ON public.tasks USING gin (num gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS tasks_notes_trgm
+  ON public.tasks USING gin (notes gin_trgm_ops);
+
+-- RLS bleibt unverändert: Indexe respektieren immer die bestehenden
+-- Project-Scoped-Policies, da Queries mit project_id-Filter laufen.
+
+COMMIT;


### PR DESCRIPTION
## ⚠️ MIGRATION — Laurenz muss SQL manuell im Supabase SQL Editor ausführen, bevor Merge

```
supabase/migrations/0008_search_trigram.sql
```

Idempotent + transaktional (`BEGIN`/`COMMIT`, `CREATE EXTENSION IF NOT EXISTS`,
`CREATE INDEX IF NOT EXISTS`). Zero-downtime — wirft bestehende Daten nicht weg.

Self-Merge ist deshalb **nicht zulässig**. Ich lasse offen.

## Was es macht

Globale Volltextsuche über `Cmd+K` (oder `/`). Tippe 2+ Zeichen und du
siehst Live-Treffer aus drei Quellen:

| Kind | Felder | Ranking |
|---|---|---|
| **Mangel** | `short_id`, `title`, `description` | trigram-similarity max() |
| **Kontakt** | `company`, `contact_name`, `email` | trigram-similarity max() |
| **Termin** | `num`, `name`, `notes` | trigram-similarity max() |

Pro Kind max. 5 Treffer, alle gemerged + nach Score absteigend sortiert.

## Stack

- **Postgres**: `pg_trgm`-Extension + GIN-Indexe mit `gin_trgm_ops` auf
  jedem search-baren Feld. Indexe respektieren RLS automatisch (Indexe
  sind nur Lookups, RLS-Policies filtern wie bisher).
- **Drizzle**: `db.execute(sql\`...\`)` mit Raw-SQL für `similarity()` +
  `ILIKE` (Drizzle hat keine native trigram-API).
- **SvelteKit**: `/api/search` als RequestHandler. Auth via globalem
  `hooks.server.ts`-Guard, Project-Membership-Check zusätzlich.
- **CommandPalette**: 220ms Debounce, monotonic Sequence-Counter gegen
  stale Responses bei schneller Tipp-Folge.

## Diff (5 Files, ~280 LoC)

| File | Was |
|---|---|
| `supabase/migrations/0008_search_trigram.sql` | NEU — Extension + 9 GIN-Indexe |
| `src/lib/db/searchQueries.ts` | NEU — `searchProject(projectId, q)` |
| `src/routes/api/search/+server.ts` | NEU — `GET /api/search?projectId&q=` |
| `src/lib/components/CommandPalette.svelte` | + Search-Hit-UI + Debounce + Navigation |
| `docs/CHANGELOG.md` | Doku |

## Self-Review

- [x] Kein `console.log` / TODO / FIXME
- [x] Edge-Case: q < 2 Zeichen → returnt `[]` ohne DB-Hit (Index-Scan
      wäre teurer als ein 50ms-Roundtrip)
- [x] Edge-Case: Race-Condition bei schnellem Tippen → `searchSeq`-Counter
      droppt stale Responses
- [x] Edge-Case: kein Project-ID in URL (z.B. `/projects`) → keine
      Suche, nur Static-Commands
- [x] SQL-Injection: Pattern-Escape für ILIKE (`\\`, `%`, `_`),
      Drizzle-Templates parametrisieren `${q}` korrekt
- [x] RLS Defense-in-Depth: explizit `userIsProjectMember()` in
      `+server.ts` zusätzlich zur RLS-Policy
- [x] Reduced-motion: keine neuen Animationen
- [x] type-check 0 errors
- [x] Tests 17/17 grün
- [x] Build clean (@sveltejs/adapter-vercel OK)
- [x] Mobile: Cmd+K-Panel ist responsive (max 560px), Touch-Targets
      auf cmdk-items 36px+ (paddings 9+9)

## Test plan (nach Migration-Run)

- [x] `pnpm check` → 0 errors
- [x] `pnpm test` → 17/17 grün
- [x] `pnpm build` → OK
- [ ] Live nach Merge:
  - [ ] Cmd+K in Projekt → leeres Input → Static-Commands sichtbar
  - [ ] `Mal` tippen → Treffer von Maler-Mängel + Maler-Kontakte erscheinen
  - [ ] `M-1` tippen → Treffer M-001/M-010/… (short_id-Match)
  - [ ] Klick auf Mangel-Treffer → navigiert nach `/<pid>/maengel/<id>`
  - [ ] ↑↓ Navigieren auch über die Hits
  - [ ] Schnelles Tippen (`M`, `Ma`, `Mal`) → keine alten Treffer-Listen
  - [ ] Außerhalb eines Projekts (z.B. `/projects`) → nur Static-Commands

## Out-of-scope (Phase 5+)

- Highlight der matching-Substring in den Ergebnissen
- Search über Aufgaben (apartment-progress) und Plan-Pins
- Recent-Searches / Favorites
- Cross-Project-Search (heute: per Project gescoped)

## Performance

GIN-Trigram-Indexe machen `ILIKE '%term%'` auf typischen Datenmengen
(< 10k Rows pro Kind) sub-millisekunden. Bei großen Notes-Feldern
kann similarity() 5-20ms kosten — bei 5 Treffern × 3 Tabellen = OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_