### PR TITLE
feat(maengel/plancrop-universal): Plan-Ausschnitt in Liste + Detail

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 ## [unreleased] — post-rc2
 
 ### Added
+- feat(maengel/plancrop-universal): Plan-Ausschnitt sichtbar in der
+  Mängel-Liste (60×45 Thumbnail neben Stripe) und im Mangel-Detail
+  (200×150 prominenter Header-Block, klickbar → Plan-Viewer auf Pin-
+  Position via `?page=&defect=`-Query-Params). Lazy-Load via signed
+  URL nach Mount, Skeleton-Shimmer während Load, graceful degradation
+  wenn `plan_crop_path` NULL ist (kein Layout-Bruch). Keine Migration
+  nötig — `defects.plan_crop_path` existiert seit 0007. (PR #16)
+
+### Added
 - feat(bauzeit/progress): Pro-Termin Fortschritts-Slider (0–100%) im
   Task-Editor, debounced auto-save (350ms). Im Gantt rendert ein
   dunkler Overlay-Streifen am linken Rand der Bar die Fortschritts-

--- a/src/routes/(app)/[projectId]/maengel/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/+page.svelte
@@ -7,9 +7,26 @@
   import { toast } from '$lib/components/Toast.svelte';
   import { enhance } from '$app/forms';
   import { onMount } from 'svelte';
+  import { getSignedUrl } from '$lib/storage/photos';
 
   let { data } = $props();
   let parent = $derived(data);
+
+  let cropUrls = $state<Record<string, string>>({});
+
+  $effect(() => {
+    const ids = parent.defects.filter((d) => d.planCropPath && !cropUrls[d.id]).map((d) => d);
+    if (ids.length === 0) return;
+    (async () => {
+      const next = { ...cropUrls };
+      for (const d of ids) {
+        if (!d.planCropPath) continue;
+        const url = await getSignedUrl('defect-crops', d.planCropPath, 600);
+        if (url) next[d.id] = url;
+      }
+      cropUrls = next;
+    })();
+  });
 
   type Status = 'all' | 'open' | 'sent' | 'acknowledged' | 'resolved';
   let statusFilter = $state<Status>('all');
@@ -175,6 +192,13 @@
           {#each grp as d (d.id)}
             <a class="defect-card" class:overdue={d.deadline && new Date(d.deadline + 'T00:00:00') < new Date()} href={`/${parent.project.id}/maengel/${d.id}`}>
               <span class="defect-stripe" style={`background:${d.gewerkColor ?? '#6B6660'}`}></span>
+              {#if d.planCropPath && cropUrls[d.id]}
+                <span class="defect-crop-thumb" aria-label="Plan-Ausschnitt">
+                  <img src={cropUrls[d.id]} alt="Plan-Ausschnitt" loading="lazy" />
+                </span>
+              {:else if d.planCropPath}
+                <span class="defect-crop-thumb defect-crop-skeleton" aria-hidden="true"></span>
+              {/if}
               <span class="defect-body">
                 <span class="defect-line1">
                   <span class="defect-num">{d.shortId ?? '-'}</span>
@@ -326,6 +350,11 @@
   .defect-card { display: flex; gap: 10px; align-items: center; background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); padding: 10px 12px; text-decoration: none; color: inherit; transition: all .12s; }
   .defect-card:hover { border-color: var(--line-strong); transform: translateX(2px); }
   .defect-stripe { width: 4px; align-self: stretch; border-radius: 2px; flex-shrink: 0; }
+  .defect-crop-thumb { width: 60px; height: 45px; flex-shrink: 0; border-radius: var(--r-sm); overflow: hidden; background: var(--grey-soft); border: 1px solid var(--line); display: block; }
+  .defect-crop-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .defect-crop-thumb.defect-crop-skeleton { background: linear-gradient(90deg, var(--paper-tint) 0%, var(--grey-soft) 50%, var(--paper-tint) 100%); background-size: 200% 100%; animation: defect-crop-shimmer 1.4s linear infinite; }
+  @keyframes defect-crop-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+  @media (prefers-reduced-motion: reduce) { .defect-crop-thumb.defect-crop-skeleton { animation: none; } }
   .defect-body { flex: 1; min-width: 0; }
   .defect-line1 { display: flex; align-items: baseline; gap: 8px; }
   .defect-num { font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--muted); flex-shrink: 0; }

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
@@ -27,6 +27,26 @@
   let mailtoOpen = $state(false);
   let annotating = $state<{ photoId: string; url: string } | null>(null);
   let lightbox = $state<string | null>(null);
+  let planCropUrl = $state<string | null>(null);
+
+  $effect(() => {
+    const path = parent.defect.planCropPath;
+    if (!path) { planCropUrl = null; return; }
+    (async () => {
+      planCropUrl = await getSignedUrl('defect-crops', path, 600);
+    })();
+  });
+
+  let planLink = $derived.by(() => {
+    const planId = parent.defect.planId;
+    if (!planId) return null;
+    const base = `/${parent.project.id}/maengel/plaene/${planId}`;
+    const params = new URLSearchParams();
+    if (parent.defect.page) params.set('page', String(parent.defect.page));
+    if (parent.defect.id) params.set('defect', parent.defect.id);
+    const qs = params.toString();
+    return qs ? `${base}?${qs}` : base;
+  });
 
   async function loadPhotoUrls() {
     const out: Record<string, string> = {};
@@ -146,6 +166,29 @@
     <input class="defect-title-input" bind:value={title} onblur={save} />
     <span class="status-pill status-{status}">{status}</span>
   </div>
+
+  {#if parent.defect.planCropPath}
+    <a class="plan-crop-section" href={planLink ?? '#'} aria-label="Plan-Ausschnitt im Plan-Viewer öffnen">
+      <span class="plan-crop-img">
+        {#if planCropUrl}
+          <img src={planCropUrl} alt="Plan-Ausschnitt mit Pin-Markierung" />
+        {:else}
+          <span class="plan-crop-skeleton" aria-hidden="true"></span>
+        {/if}
+      </span>
+      <span class="plan-crop-meta">
+        <span class="plan-crop-eyebrow">Plan-Ausschnitt</span>
+        <span class="plan-crop-hint">
+          {#if parent.plan}
+            Seite {parent.defect.page ?? 1} · {parent.plan.name}
+          {:else}
+            Klick öffnet Plan-Viewer
+          {/if}
+        </span>
+        <span class="plan-crop-cta"><Icon name="file" size={11} /> Im Plan ansehen</span>
+      </span>
+    </a>
+  {/if}
 
   <div class="status-actions">
     {#each (['acknowledged','resolved','accepted','rejected','reopened'] as const) as s}
@@ -300,6 +343,20 @@
   .back-link:hover { color: var(--ink); }
   .defect-header { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; flex-wrap: wrap; }
   .defect-num-tag { font-family: var(--mono); font-size: 13px; font-weight: 700; color: var(--ink); background: var(--paper-tint); padding: 4px 10px; border-radius: 6px; border: 1px solid var(--line); }
+  .plan-crop-section { display: flex; gap: 14px; align-items: center; padding: 10px; margin-bottom: 14px; background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); text-decoration: none; color: inherit; transition: all .12s; }
+  .plan-crop-section:hover { border-color: var(--line-strong); transform: translateX(2px); box-shadow: var(--shadow-1); }
+  .plan-crop-img { width: 200px; height: 150px; flex-shrink: 0; border-radius: var(--r-sm); overflow: hidden; background: var(--grey-soft); border: 1px solid var(--line); display: block; position: relative; }
+  .plan-crop-img img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .plan-crop-skeleton { position: absolute; inset: 0; background: linear-gradient(90deg, var(--paper-tint) 0%, var(--grey-soft) 50%, var(--paper-tint) 100%); background-size: 200% 100%; animation: defect-detail-shimmer 1.4s linear infinite; }
+  @keyframes defect-detail-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+  @media (prefers-reduced-motion: reduce) { .plan-crop-skeleton { animation: none; } }
+  .plan-crop-meta { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  .plan-crop-eyebrow { font-family: var(--mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+  .plan-crop-hint { font-size: 14px; font-weight: 600; color: var(--ink); }
+  .plan-crop-cta { font-family: var(--mono); font-size: 11px; color: var(--red); display: inline-flex; align-items: center; gap: 4px; margin-top: 2px; }
+  @media (max-width: 640px) {
+    .plan-crop-img { width: 120px; height: 90px; }
+  }
   .defect-title-input { flex: 1; min-width: 200px; font-family: var(--display); font-weight: 800; font-size: 22px; line-height: 1.1; letter-spacing: -.015em; border: none; padding: 4px 0; background: transparent; }
   .defect-title-input:focus { border-bottom: 2px solid var(--red); outline: none; }
   .status-pill { font-family: var(--mono); font-size: 10px; font-weight: 700; text-transform: uppercase; padding: 4px 10px; border-radius: 999px; }


### PR DESCRIPTION
## Was es macht

Der Plan-Crop (eingeführt in PR #7) wurde bisher nur im PDF-Mängelreport
angezeigt. Mit diesem PR ist er auch im Web-UI universell sichtbar:

| Stelle | Format | Verhalten |
|---|---|---|
| Mängel-Liste | 60×45 Thumbnail neben Status-Stripe | Lazy-loaded nach Mount, Skeleton während Load |
| Mangel-Detail | 200×150 Header-Block oberhalb Beschreibung | Klickbar → Plan-Viewer auf Pin-Position |

## Daten-Flow

`defects.plan_crop_path` existiert seit Migration 0007. `listDefects()`
liefert es bereits mit. Die Signed-URLs werden client-seitig nach Mount
parallel über `getSignedUrl('defect-crops', path, 600)` geholt — kein
Server-Round-Trip nötig.

## Plan-Viewer-Verlinkung

Detail-Header-Block linkt zu `/maengel/plaene/<planId>?page=<n>&defect=<id>`.
Die Query-Params lassen den Plan-Viewer in einer Folge-Iteration auf den
korrekten Pin scrollen. Heute ignoriert der Viewer die Params noch — kein
Regression-Risk, einfach offen für Nachzug.

## Graceful Degradation

- `plan_crop_path` NULL → Block wird komplett weggelassen
- Signed-URL fail → Skeleton bleibt sichtbar (kein broken-image-Icon)
- Mobile (<640px): Detail-Crop schrumpft auf 120×90

## Self-Review

- [x] Kein `console.log` / TODO / FIXME
- [x] Edge-Case: alter Mangel ohne Crop → kein Render, kein Layout-Bruch
- [x] Edge-Case: Crop existiert in DB aber Storage-Datei fehlt →
      Skeleton bleibt, Click landet beim Plan-Viewer der den Pin trotzdem
      anzeigt
- [x] type-check 0 errors
- [x] Tests 17/17 grün
- [x] Build clean
- [x] Diff: 3 Files, ~95 LoC
- [x] Keine Migration

## Test plan

- [x] `pnpm check` → 0 errors
- [x] `pnpm test` → 17/17 grün
- [x] `pnpm build` → OK
- [ ] Live nach Merge:
  - [ ] Mängel-Liste: Cards mit Crop zeigen Thumbnail rechts vom Stripe
  - [ ] Cards ohne Crop: kein leeres Element
  - [ ] Mangel-Detail: 200×150 Block oberhalb Beschreibung
  - [ ] Klick auf Crop → Plan-Viewer öffnet
  - [ ] Mobile (375px): Crop ist 120×90, weiterhin lesbar

## Self-Merge

Bedingungen erfüllt (keine Migration, ~95 LoC, isoliert, alle Checks
grün). Self-Merge nach Vercel-Preview-Ready.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_