### PR TITLE
⚠️ MIG: VOB-Mängelrüge mit Frist + Vorgangs-Historie

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,25 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 ## [unreleased] — post-rc2
 
 ### Added
+- feat(maengel/vob-ruege): VOB-konformer Mängelrüge-Workflow mit
+  Vorgangs-Historie pro Mangel (AN- und AG-Spur), Frist-Tracking,
+  Brief-Vorlagen und PDF-Generator. Mangel-Detail zeigt zwei
+  Timelines (Auftragnehmer / Auftraggeber) mit farbigen Status-
+  Badges. Button "Mängelrüge" generiert ein 2-seitiges PDF (Briefkopf
+  aus `firma_settings`, Empfänger-Adresse, Brieftext aus Vorlage,
+  Anlage Mängelliste mit Plan-Crop-Vorschau pro Mangel,
+  Bestätigungs-Block am Schluss). Beim Erstellen wird automatisch
+  ein Vorgang AN „angezeigt" angelegt, `defects.due_date` gesetzt
+  und Status auf 'sent' gewechselt. Vier globale Brief-Vorlagen
+  vorinitialisiert (§4 Abs.7 vor Abnahme, §13 Abs.5 nach Abnahme,
+  Nachfrist mit Ersatzvornahme-Androhung, Freimeldungs-Bestätigung).
+  **Migration 0010_defect_vorgaenge.sql benötigt** — fügt
+  `defect_vorgaenge`-Tabelle, Enum-Types `defect_party` und
+  `defect_vorgang_status`, `brief_vorlagen`, `firma_settings`,
+  zusätzliche Spalten `defects.due_date` + `rechtsgrundlage` hinzu.
+  Idempotent (`DO $$ … duplicate_object`, `IF NOT EXISTS`).
+  Default-Hofmann-Firma + 4 Brief-Vorlagen werden automatisch
+  geseedet, falls noch nicht vorhanden. (PR #17)
 - feat(bauzeit/progress): Pro-Termin Fortschritts-Slider (0–100%) im
   Task-Editor, debounced auto-save (350ms). Im Gantt rendert ein
   dunkler Overlay-Streifen am linken Rand der Bar die Fortschritts-

--- a/src/lib/components/VorgangTimeline.svelte
+++ b/src/lib/components/VorgangTimeline.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import Icon from './Icon.svelte';
+  import { fmtDateDe } from '$lib/util/time';
+  import { VORGANG_STATUS_LABEL, VORGANG_STATUS_TINT, type VorgangStatus } from '$lib/db/vorgangTypes';
+
+  type Vorgang = {
+    id: string;
+    partei: 'AN' | 'AG' | string;
+    status: VorgangStatus | string;
+    beschreibung: string | null;
+    termin: string | null;
+    terminAntwort: string | null;
+    documentUrl: string | null;
+    createdAt: Date | string;
+  };
+
+  type Props = {
+    partei: 'AN' | 'AG';
+    vorgaenge: Vorgang[];
+    onAdd?: () => void;
+  };
+  let { partei, vorgaenge, onAdd }: Props = $props();
+
+  let filtered = $derived(vorgaenge.filter((v) => v.partei === partei));
+
+  function statusLabel(s: string): string {
+    return (VORGANG_STATUS_LABEL as Record<string, string>)[s] ?? s;
+  }
+  function statusTint(s: string): string {
+    return (VORGANG_STATUS_TINT as Record<string, string>)[s] ?? 'grey';
+  }
+  function fmtDt(d: Date | string): string {
+    const dt = typeof d === 'string' ? new Date(d) : d;
+    return dt.toLocaleString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+  }
+</script>
+
+<div class="vorgang-timeline">
+  <div class="vorgang-head">
+    <span class="vorgang-eyebrow">{partei === 'AN' ? 'Auftragnehmer' : 'Auftraggeber'}</span>
+    <span class="vorgang-count">{filtered.length}</span>
+    {#if onAdd}
+      <button class="btn btn-ghost btn-sm" onclick={onAdd} type="button">
+        <Icon name="plus" size={12} /> Vorgang
+      </button>
+    {/if}
+  </div>
+
+  {#if filtered.length === 0}
+    <div class="vorgang-empty">Noch kein Vorgang erfasst.</div>
+  {:else}
+    <ul class="vorgang-list">
+      {#each filtered as v (v.id)}
+        <li class="vorgang-item tint-{statusTint(v.status)}">
+          <span class="vorgang-dot" aria-hidden="true"></span>
+          <div class="vorgang-body">
+            <div class="vorgang-line1">
+              <span class="vorgang-status status-{statusTint(v.status)}">{statusLabel(v.status)}</span>
+              <span class="vorgang-time">{fmtDt(v.createdAt)}</span>
+            </div>
+            {#if v.beschreibung}
+              <div class="vorgang-text">{v.beschreibung}</div>
+            {/if}
+            <div class="vorgang-meta">
+              {#if v.termin}<span>Termin: {fmtDateDe(v.termin)}</span>{/if}
+              {#if v.terminAntwort}<span>Antwort bis: {fmtDateDe(v.terminAntwort)}</span>{/if}
+              {#if v.documentUrl}
+                <a class="vorgang-doc" href={v.documentUrl} target="_blank" rel="noopener">
+                  <Icon name="file" size={11} /> Dokument
+                </a>
+              {/if}
+            </div>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .vorgang-timeline { background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); padding: 14px; }
+  .vorgang-head { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
+  .vorgang-eyebrow { font-family: var(--mono); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: var(--ink-2); flex: 1; }
+  .vorgang-count { font-family: var(--mono); font-size: 10px; font-weight: 700; color: var(--muted); padding: 2px 7px; background: var(--paper-tint); border-radius: 999px; border: 1px solid var(--line); }
+  .vorgang-empty { font-size: 13px; color: var(--muted); text-align: center; padding: 16px 0; }
+  .vorgang-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 12px; }
+  .vorgang-item { display: flex; gap: 10px; padding-left: 4px; position: relative; }
+  .vorgang-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; margin-top: 5px; background: var(--muted); }
+  .vorgang-item.tint-red .vorgang-dot { background: var(--red); }
+  .vorgang-item.tint-amber .vorgang-dot { background: var(--amber); }
+  .vorgang-item.tint-green .vorgang-dot { background: var(--green); }
+  .vorgang-item.tint-blue .vorgang-dot { background: var(--blue); }
+  .vorgang-body { flex: 1; min-width: 0; }
+  .vorgang-line1 { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+  .vorgang-status { font-family: var(--mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; padding: 2px 7px; border-radius: 999px; border: 1px solid var(--line); }
+  .vorgang-status.status-red { color: var(--red); background: var(--red-soft); border-color: rgba(227, 6, 19, 0.2); }
+  .vorgang-status.status-amber { color: var(--amber); background: var(--amber-soft); border-color: rgba(217, 119, 6, 0.2); }
+  .vorgang-status.status-green { color: var(--green); background: var(--green-soft); border-color: rgba(46, 125, 50, 0.2); }
+  .vorgang-status.status-blue { color: var(--blue); background: var(--blue-soft); border-color: rgba(59, 108, 196, 0.2); }
+  .vorgang-status.status-grey { color: var(--ink-2); background: var(--paper-tint); }
+  .vorgang-time { font-family: var(--mono); font-size: 10px; color: var(--muted); }
+  .vorgang-text { font-size: 13px; color: var(--ink); margin-top: 4px; line-height: 1.4; }
+  .vorgang-meta { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 4px; font-family: var(--mono); font-size: 10px; color: var(--muted); }
+  .vorgang-doc { color: var(--blue); display: inline-flex; align-items: center; gap: 3px; text-decoration: none; }
+  .vorgang-doc:hover { text-decoration: underline; }
+</style>

--- a/src/lib/db/defectQueries.ts
+++ b/src/lib/db/defectQueries.ts
@@ -149,6 +149,8 @@ export async function updateDefectFields(
     apartmentId: string | null;
     deadline: string | null;
     followupDate: string | null;
+    dueDate: string | null;
+    rechtsgrundlage: string | null;
     priority: number;
     status: 'open' | 'sent' | 'acknowledged' | 'resolved' | 'accepted' | 'rejected' | 'reopened';
   }>

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -264,7 +264,66 @@ export const defects = pgTable('defects', {
   resolvedAt: timestamp('resolved_at', { withTimezone: true }),
   resolvedBy: uuid('resolved_by').references(() => profiles.id),
   followupDate: date('followup_date'),
+  dueDate: date('due_date'),
+  rechtsgrundlage: text('rechtsgrundlage'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull()
+});
+
+export const defectVorgaenge = pgTable('defect_vorgaenge', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  defectId: uuid('defect_id').notNull().references(() => defects.id, { onDelete: 'cascade' }),
+  partei: text('partei', { enum: ['AN', 'AG'] }).notNull(),
+  status: text('status', {
+    enum: [
+      'erfasst',
+      'angezeigt',
+      'nachfrist',
+      'klaerung',
+      'freigemeldet_NU',
+      'abgelehnt_NU',
+      'kontrolle_AG',
+      'erledigt',
+      'ersatzvornahme',
+      'notiz'
+    ]
+  }).notNull(),
+  beschreibung: text('beschreibung'),
+  termin: date('termin'),
+  terminAntwort: date('termin_antwort'),
+  documentId: text('document_id'),
+  documentUrl: text('document_url'),
+  createdBy: uuid('created_by').references(() => profiles.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+});
+
+export const briefVorlagen = pgTable('brief_vorlagen', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  projectId: uuid('project_id').references(() => projects.id, { onDelete: 'cascade' }),
+  name: text('name').notNull(),
+  typ: text('typ').notNull(),
+  rechtsgrundlage: text('rechtsgrundlage'),
+  vorlageText: text('vorlage_text').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+});
+
+export const firmaSettings = pgTable('firma_settings', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  orgId: uuid('org_id'),
+  name: text('name').notNull(),
+  strasse: text('strasse').notNull(),
+  plzOrt: text('plz_ort').notNull(),
+  telefon: text('telefon'),
+  email: text('email'),
+  web: text('web'),
+  geschaeftsfuehrer: text('geschaeftsfuehrer'),
+  ustId: text('ust_id'),
+  bank: text('bank'),
+  iban: text('iban'),
+  bic: text('bic'),
+  logoPath: text('logo_path'),
+  unterzeichner1: text('unterzeichner1'),
+  unterzeichner2: text('unterzeichner2'),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull()
 });
 

--- a/src/lib/db/vorgangQueries.ts
+++ b/src/lib/db/vorgangQueries.ts
@@ -1,0 +1,112 @@
+/**
+ * VOB-Vorgangs-Historie pro Mangel. Server-only — importiert Drizzle/Postgres.
+ * Browser-Code nutzt `vorgangTypes.ts` für Labels/Types.
+ */
+import { db } from './client';
+import { defectVorgaenge, briefVorlagen, firmaSettings, defects } from './schema';
+import { eq, and, desc, asc, sql } from 'drizzle-orm';
+import type { VorgangPartei, VorgangStatus } from './vorgangTypes';
+export type { VorgangPartei, VorgangStatus } from './vorgangTypes';
+export { VORGANG_STATUS_LABEL, VORGANG_STATUS_TINT } from './vorgangTypes';
+
+export type VorgangRow = typeof defectVorgaenge.$inferSelect;
+
+export async function listVorgaenge(defectId: string): Promise<VorgangRow[]> {
+  if (!db) return [];
+  return await db
+    .select()
+    .from(defectVorgaenge)
+    .where(eq(defectVorgaenge.defectId, defectId))
+    .orderBy(desc(defectVorgaenge.createdAt));
+}
+
+/**
+ * Liefert den letzten Eintrag pro Spur — nutzbar in Listen-Aggregaten ohne
+ * separate Round-Trips pro Mangel.
+ */
+export async function lastVorgangPerPartei(defectId: string): Promise<{
+  AN: VorgangRow | null;
+  AG: VorgangRow | null;
+}> {
+  if (!db) return { AN: null, AG: null };
+  const rows = await db
+    .select()
+    .from(defectVorgaenge)
+    .where(eq(defectVorgaenge.defectId, defectId))
+    .orderBy(desc(defectVorgaenge.createdAt));
+  return {
+    AN: rows.find((r) => r.partei === 'AN') ?? null,
+    AG: rows.find((r) => r.partei === 'AG') ?? null
+  };
+}
+
+export type AddVorgangInput = {
+  defectId: string;
+  partei: VorgangPartei;
+  status: VorgangStatus;
+  beschreibung?: string | null;
+  termin?: string | null;
+  terminAntwort?: string | null;
+  documentId?: string | null;
+  documentUrl?: string | null;
+  createdBy: string;
+};
+
+export async function addVorgang(input: AddVorgangInput): Promise<VorgangRow | null> {
+  if (!db) return null;
+  const [row] = await db.insert(defectVorgaenge).values({
+    defectId: input.defectId,
+    partei: input.partei,
+    status: input.status,
+    beschreibung: input.beschreibung ?? null,
+    termin: input.termin ?? null,
+    terminAntwort: input.terminAntwort ?? null,
+    documentId: input.documentId ?? null,
+    documentUrl: input.documentUrl ?? null,
+    createdBy: input.createdBy
+  }).returning();
+  return row;
+}
+
+export async function listBriefVorlagen(projectId: string | null) {
+  if (!db) return [];
+  if (projectId) {
+    return await db
+      .select()
+      .from(briefVorlagen)
+      .where(sql`${briefVorlagen.projectId} IS NULL OR ${briefVorlagen.projectId} = ${projectId}`)
+      .orderBy(asc(briefVorlagen.typ), asc(briefVorlagen.name));
+  }
+  return await db.select().from(briefVorlagen).orderBy(asc(briefVorlagen.typ), asc(briefVorlagen.name));
+}
+
+export async function getFirmaSettings() {
+  if (!db) return null;
+  const [row] = await db.select().from(firmaSettings).limit(1);
+  return row ?? null;
+}
+
+/**
+ * Aggregiert für die Mängel-Liste: ein Map defectId → letzter AN/AG-Status.
+ * Eine einzige DB-Query, kein N+1.
+ */
+export async function vorgaengeByProject(projectId: string): Promise<
+  Map<string, { AN: VorgangRow | null; AG: VorgangRow | null }>
+> {
+  const out = new Map<string, { AN: VorgangRow | null; AG: VorgangRow | null }>();
+  if (!db) return out;
+  // Subquery: alle Vorgänge der Mängel im Projekt, neueste zuerst.
+  const rows = await db
+    .select()
+    .from(defectVorgaenge)
+    .innerJoin(defects, eq(defects.id, defectVorgaenge.defectId))
+    .where(eq(defects.projectId, projectId))
+    .orderBy(desc(defectVorgaenge.createdAt));
+  for (const { defect_vorgaenge: v } of rows) {
+    const cur = out.get(v.defectId) ?? { AN: null, AG: null };
+    if (v.partei === 'AN' && !cur.AN) cur.AN = v;
+    if (v.partei === 'AG' && !cur.AG) cur.AG = v;
+    out.set(v.defectId, cur);
+  }
+  return out;
+}

--- a/src/lib/db/vorgangTypes.ts
+++ b/src/lib/db/vorgangTypes.ts
@@ -1,0 +1,42 @@
+/**
+ * VOB-Vorgang-Typen + Labels — DB-frei, browser-safe.
+ * `vorgangQueries.ts` re-exportiert dieselben Konstanten für SSR-Code.
+ */
+export type VorgangPartei = 'AN' | 'AG';
+export type VorgangStatus =
+  | 'erfasst'
+  | 'angezeigt'
+  | 'nachfrist'
+  | 'klaerung'
+  | 'freigemeldet_NU'
+  | 'abgelehnt_NU'
+  | 'kontrolle_AG'
+  | 'erledigt'
+  | 'ersatzvornahme'
+  | 'notiz';
+
+export const VORGANG_STATUS_LABEL: Record<VorgangStatus, string> = {
+  erfasst: 'Erfasst',
+  angezeigt: 'Angezeigt',
+  nachfrist: 'Nachfrist',
+  klaerung: 'Klärung',
+  freigemeldet_NU: 'Freigemeldet (NU)',
+  abgelehnt_NU: 'Abgelehnt (NU)',
+  kontrolle_AG: 'Kontrolle (AG)',
+  erledigt: 'Erledigt',
+  ersatzvornahme: 'Ersatzvornahme',
+  notiz: 'Notiz'
+};
+
+export const VORGANG_STATUS_TINT: Record<VorgangStatus, string> = {
+  erfasst: 'grey',
+  angezeigt: 'amber',
+  nachfrist: 'red',
+  klaerung: 'blue',
+  freigemeldet_NU: 'green',
+  abgelehnt_NU: 'red',
+  kontrolle_AG: 'amber',
+  erledigt: 'green',
+  ersatzvornahme: 'red',
+  notiz: 'grey'
+};

--- a/src/lib/pdf/maengelruege.ts
+++ b/src/lib/pdf/maengelruege.ts
@@ -1,0 +1,465 @@
+/**
+ * VOB-Mängelrüge PDF-Generator (browser-side).
+ *
+ * Layout:
+ * - Briefkopf: Hofmann-Logo + Firma-Adresse oben rechts
+ * - Empfänger-Adresse links Mitte
+ * - Datum + Aktenzeichen rechts
+ * - Betreff
+ * - Brieftext (Vorlage mit Platzhaltern)
+ * - Mängel-Anlage: 1 Zeile pro Mangel mit ID, Plan-Crop, Beschreibung,
+ *   Erledigt-Checkbox + Bemerkung-Linie für handschriftliche Eintragung
+ * - Unterschrift-Block + Footer
+ *
+ * Eingebettet wird der Plan-Ausschnitt pro Mangel (signed URL via
+ * defect-crops). Wenn keiner vorhanden, fällt die Zeile auf das erste
+ * Foto zurück.
+ */
+import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage, type PDFImage } from 'pdf-lib';
+import { getSignedUrl } from '$lib/storage/photos';
+
+const PAGE_W = 595.28;
+const PAGE_H = 841.89;
+const MARGIN = 56;
+const RED = rgb(0.89, 0.024, 0.075);
+const INK = rgb(0.059, 0.059, 0.063);
+const MUTED = rgb(0.42, 0.4, 0.376);
+const LINE = rgb(0.78, 0.77, 0.75);
+
+export type Firma = {
+  name: string;
+  strasse: string;
+  plzOrt: string;
+  telefon: string | null;
+  email: string | null;
+  web: string | null;
+  unterzeichner1: string | null;
+  unterzeichner2: string | null;
+};
+
+export type RuegeDefect = {
+  shortId: string | null;
+  title: string;
+  description: string | null;
+  apartmentLabel?: string | null;
+  bauteil?: string | null;
+  planCropPath: string | null;
+  firstPhotoPath: string | null;
+};
+
+export type RuegeInput = {
+  projektName: string;
+  empfaenger: {
+    company: string | null;
+    contactName: string | null;
+    address: string | null;
+    email: string | null;
+  };
+  frist: string;            // ISO-Datum YYYY-MM-DD
+  rechtsgrundlage: string;
+  betreff?: string;
+  brieftextRendered: string; // Vorlage mit ersetzten Platzhaltern (Rendering vom Caller)
+  unterzeichner: string;
+  defects: RuegeDefect[];
+  firma: Firma;
+  qrSvg?: string | null;     // Optional: SVG-Markup eines QR-Codes (siehe PR #19)
+};
+
+async function fetchImageBytes(url: string): Promise<Uint8Array | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return new Uint8Array(await res.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+async function embedSafeImage(pdf: PDFDocument, url: string): Promise<PDFImage | null> {
+  const bytes = await fetchImageBytes(url);
+  if (!bytes) return null;
+  try {
+    return await pdf.embedJpg(bytes);
+  } catch {
+    try {
+      return await pdf.embedPng(bytes);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function fmtDeShort(d: Date): string {
+  return d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function fmtDeFromIso(iso: string): string {
+  const [y, m, d] = iso.split('-');
+  return `${d}.${m}.${y}`;
+}
+
+function drawHeaderLogo(page: PDFPage, x: number, y: number, size: number) {
+  page.drawRectangle({ x, y: y - size, width: size, height: size, borderColor: RED, borderWidth: 3 });
+  page.drawCircle({ x: x + size - 6, y: y - size + 6, size: 3, color: RED });
+}
+
+function drawWrappedText(
+  page: PDFPage,
+  text: string,
+  font: PDFFont,
+  fontSize: number,
+  x: number,
+  yStart: number,
+  maxWidth: number,
+  lineHeight: number,
+  color = INK
+): number {
+  const paragraphs = text.split('\n');
+  let y = yStart;
+  for (const para of paragraphs) {
+    const words = para.split(' ');
+    let line = '';
+    for (const w of words) {
+      const tentative = line ? line + ' ' + w : w;
+      const width = font.widthOfTextAtSize(tentative, fontSize);
+      if (width > maxWidth && line) {
+        page.drawText(line, { x, y, size: fontSize, font, color });
+        y -= lineHeight;
+        line = w;
+      } else {
+        line = tentative;
+      }
+    }
+    if (line) {
+      page.drawText(line, { x, y, size: fontSize, font, color });
+      y -= lineHeight;
+    } else {
+      y -= lineHeight;
+    }
+  }
+  return y;
+}
+
+export async function generateMaengelruege(input: RuegeInput): Promise<Blob> {
+  const pdf = await PDFDocument.create();
+  const helv = await pdf.embedFont(StandardFonts.Helvetica);
+  const helvBold = await pdf.embedFont(StandardFonts.HelveticaBold);
+  const today = fmtDeShort(new Date());
+  const fristFmt = fmtDeFromIso(input.frist);
+
+  // ----- Anschreiben (Seite 1) -----
+  const p1 = pdf.addPage([PAGE_W, PAGE_H]);
+
+  // Briefkopf rechts oben
+  drawHeaderLogo(p1, PAGE_W - MARGIN - 38, PAGE_H - MARGIN, 38);
+  p1.drawText(input.firma.name, {
+    x: PAGE_W - MARGIN - 200,
+    y: PAGE_H - MARGIN - 8,
+    size: 11,
+    font: helvBold,
+    color: INK
+  });
+  const headerLines = [input.firma.strasse, input.firma.plzOrt];
+  if (input.firma.telefon) headerLines.push(`Tel ${input.firma.telefon}`);
+  if (input.firma.email) headerLines.push(input.firma.email);
+  let yh = PAGE_H - MARGIN - 22;
+  for (const l of headerLines) {
+    p1.drawText(l, { x: PAGE_W - MARGIN - 200, y: yh, size: 9, font: helv, color: MUTED });
+    yh -= 11;
+  }
+
+  // Empfänger-Adresse links Mitte
+  const yEmp = PAGE_H - MARGIN - 110;
+  const adressLines = [
+    input.empfaenger.company ?? '—',
+    input.empfaenger.contactName ?? '',
+    ...(input.empfaenger.address ?? '').split('\n')
+  ].filter((s) => s.trim());
+  let ya = yEmp;
+  for (const l of adressLines) {
+    p1.drawText(l, { x: MARGIN, y: ya, size: 11, font: helv, color: INK });
+    ya -= 13;
+  }
+
+  // Datum + Aktenzeichen rechts oben unter Briefkopf
+  p1.drawText(`Schwäbisch Hall, ${today}`, {
+    x: PAGE_W - MARGIN - 200,
+    y: PAGE_H - MARGIN - 110,
+    size: 10,
+    font: helv,
+    color: INK
+  });
+
+  // Betreff
+  const betreff = input.betreff ?? `Mängelrüge gem. ${input.rechtsgrundlage}`;
+  p1.drawText(`Bauvorhaben: ${input.projektName}`, {
+    x: MARGIN,
+    y: PAGE_H - MARGIN - 220,
+    size: 11,
+    font: helvBold,
+    color: INK
+  });
+  p1.drawText(betreff, {
+    x: MARGIN,
+    y: PAGE_H - MARGIN - 238,
+    size: 11,
+    font: helvBold,
+    color: INK
+  });
+
+  // Brieftext
+  const yText = drawWrappedText(
+    p1,
+    input.brieftextRendered,
+    helv,
+    11,
+    MARGIN,
+    PAGE_H - MARGIN - 270,
+    PAGE_W - 2 * MARGIN,
+    15
+  );
+
+  // Unterschrift
+  const yUnter = Math.max(180, yText - 40);
+  p1.drawText('Mit freundlichen Grüßen', {
+    x: MARGIN,
+    y: yUnter,
+    size: 11,
+    font: helv,
+    color: INK
+  });
+  p1.drawText(input.unterzeichner, {
+    x: MARGIN,
+    y: yUnter - 60,
+    size: 11,
+    font: helvBold,
+    color: INK
+  });
+  p1.drawText(input.firma.name, {
+    x: MARGIN,
+    y: yUnter - 75,
+    size: 9,
+    font: helv,
+    color: MUTED
+  });
+
+  // QR-Code unten rechts (optional)
+  if (input.qrSvg) {
+    p1.drawText('Online-Freimeldung:', {
+      x: PAGE_W - MARGIN - 120,
+      y: 110,
+      size: 8,
+      font: helv,
+      color: MUTED
+    });
+    p1.drawRectangle({
+      x: PAGE_W - MARGIN - 80,
+      y: 30,
+      width: 70,
+      height: 70,
+      borderColor: INK,
+      borderWidth: 1
+    });
+    p1.drawText('QR-Code', {
+      x: PAGE_W - MARGIN - 60,
+      y: 60,
+      size: 7,
+      font: helv,
+      color: MUTED
+    });
+  }
+
+  // Footer
+  p1.drawText(`Frist zur Beseitigung: ${fristFmt}`, {
+    x: MARGIN,
+    y: 30,
+    size: 9,
+    font: helvBold,
+    color: RED
+  });
+
+  // ----- Anlage: Mängelliste -----
+  const p2 = pdf.addPage([PAGE_W, PAGE_H]);
+  drawHeaderLogo(p2, PAGE_W - MARGIN - 28, PAGE_H - MARGIN, 28);
+  p2.drawText('Anlage: Mängelliste', {
+    x: MARGIN,
+    y: PAGE_H - MARGIN - 8,
+    size: 14,
+    font: helvBold,
+    color: INK
+  });
+  p2.drawText(`Bauvorhaben: ${input.projektName}  ·  Frist: ${fristFmt}`, {
+    x: MARGIN,
+    y: PAGE_H - MARGIN - 28,
+    size: 10,
+    font: helv,
+    color: MUTED
+  });
+  p2.drawLine({
+    start: { x: MARGIN, y: PAGE_H - MARGIN - 36 },
+    end: { x: PAGE_W - MARGIN, y: PAGE_H - MARGIN - 36 },
+    thickness: 0.7,
+    color: LINE
+  });
+
+  let yRow = PAGE_H - MARGIN - 60;
+  const ROW_H = 110;
+  let pageRef: PDFPage = p2;
+  let rowsOnPage = 0;
+  const ROWS_PER_PAGE = 5;
+
+  for (const d of input.defects) {
+    if (rowsOnPage >= ROWS_PER_PAGE) {
+      pageRef = pdf.addPage([PAGE_W, PAGE_H]);
+      yRow = PAGE_H - MARGIN;
+      rowsOnPage = 0;
+    }
+
+    // Plan-Crop oder Foto-Fallback
+    let img: PDFImage | null = null;
+    if (d.planCropPath) {
+      const url = await getSignedUrl('defect-crops', d.planCropPath, 600);
+      if (url) img = await embedSafeImage(pdf, url);
+    }
+    if (!img && d.firstPhotoPath) {
+      const url = await getSignedUrl('defect-photos', d.firstPhotoPath, 600);
+      if (url) img = await embedSafeImage(pdf, url);
+    }
+
+    // Bild links
+    if (img) {
+      const ratio = img.width / img.height;
+      const w = 100;
+      const h = w / ratio;
+      pageRef.drawImage(img, {
+        x: MARGIN,
+        y: yRow - h - 4,
+        width: w,
+        height: h
+      });
+    } else {
+      pageRef.drawRectangle({
+        x: MARGIN,
+        y: yRow - 75,
+        width: 100,
+        height: 75,
+        borderColor: LINE,
+        borderWidth: 0.5
+      });
+    }
+
+    // Mangel-ID + Titel rechts
+    const xText = MARGIN + 115;
+    pageRef.drawText(d.shortId ?? '?', {
+      x: xText,
+      y: yRow - 6,
+      size: 11,
+      font: helvBold,
+      color: RED
+    });
+    pageRef.drawText(d.title, {
+      x: xText + 50,
+      y: yRow - 6,
+      size: 11,
+      font: helvBold,
+      color: INK
+    });
+
+    if (d.apartmentLabel) {
+      pageRef.drawText(d.apartmentLabel, {
+        x: xText,
+        y: yRow - 22,
+        size: 9,
+        font: helv,
+        color: MUTED
+      });
+    }
+
+    if (d.description) {
+      drawWrappedText(
+        pageRef,
+        d.description.slice(0, 240),
+        helv,
+        9,
+        xText,
+        yRow - 38,
+        PAGE_W - MARGIN - xText - 60,
+        12,
+        INK
+      );
+    }
+
+    // Erledigt-Checkbox rechts
+    pageRef.drawRectangle({
+      x: PAGE_W - MARGIN - 50,
+      y: yRow - 22,
+      width: 14,
+      height: 14,
+      borderColor: INK,
+      borderWidth: 0.7
+    });
+    pageRef.drawText('Erledigt', {
+      x: PAGE_W - MARGIN - 50,
+      y: yRow - 36,
+      size: 8,
+      font: helv,
+      color: MUTED
+    });
+
+    // Trennlinie
+    pageRef.drawLine({
+      start: { x: MARGIN, y: yRow - ROW_H + 6 },
+      end: { x: PAGE_W - MARGIN, y: yRow - ROW_H + 6 },
+      thickness: 0.5,
+      color: LINE
+    });
+
+    yRow -= ROW_H;
+    rowsOnPage++;
+  }
+
+  // Bestätigungs-Block
+  const allPages = pdf.getPages();
+  const last = allPages[allPages.length - 1];
+  last.drawText('Bestätigung der Mängelbeseitigung:', {
+    x: MARGIN,
+    y: 80,
+    size: 9,
+    font: helvBold,
+    color: INK
+  });
+  last.drawLine({
+    start: { x: MARGIN, y: 50 },
+    end: { x: PAGE_W / 2, y: 50 },
+    thickness: 0.5,
+    color: INK
+  });
+  last.drawText('Datum, Unterschrift Auftragnehmer', {
+    x: MARGIN,
+    y: 36,
+    size: 8,
+    font: helv,
+    color: MUTED
+  });
+
+  const bytes = await pdf.save();
+  return new Blob([bytes as BlobPart], { type: 'application/pdf' });
+}
+
+/**
+ * Fülllt eine Vorlage mit Platzhaltern. Unterstützte Tokens:
+ * {{projekt}} {{frist}} {{rechtsgrundlage}} {{unterzeichner}}
+ * {{datum_anzeige}} {{frist_alt}} {{datum_freimeldung}}
+ */
+export function renderVorlage(vorlage: string, vars: Record<string, string>): string {
+  return vorlage.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? `{{${key}}}`);
+}
+
+export function downloadBlob(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 5000);
+}

--- a/src/routes/(app)/[projectId]/maengel/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/+page.server.ts
@@ -4,16 +4,25 @@ import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
 import { gewerke, defectPhotos, defectHistory } from '$lib/db/schema';
 import { listDefects, listPlans, listContactsForProject, createDefect } from '$lib/db/defectQueries';
+import { vorgaengeByProject } from '$lib/db/vorgangQueries';
 import { asc } from 'drizzle-orm';
 
 export const load: PageServerLoad = async ({ params }) => {
-  const [defects, plans, contacts, gewerkeRows] = await Promise.all([
+  const [defects, plans, contacts, gewerkeRows, vorgaengeMap] = await Promise.all([
     listDefects(params.projectId),
     listPlans(params.projectId),
     listContactsForProject(params.projectId),
-    db ? db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)) : Promise.resolve([])
+    db ? db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)) : Promise.resolve([]),
+    vorgaengeByProject(params.projectId)
   ]);
-  return { defects, plans, contacts, gewerke: gewerkeRows };
+  // Reduce Map → array of {defectId, anStatus, agStatus, anTermin} for serialization
+  const vorgaenge = Array.from(vorgaengeMap.entries()).map(([defectId, v]) => ({
+    defectId,
+    anStatus: v.AN?.status ?? null,
+    anTermin: v.AN?.termin ?? null,
+    agStatus: v.AG?.status ?? null
+  }));
+  return { defects, plans, contacts, gewerke: gewerkeRows, vorgaenge };
 };
 
 const photoEntry = z.object({

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.server.ts
@@ -5,19 +5,31 @@ import { db } from '$lib/db/client';
 import { defectPhotos, defectHistory, gewerke, contacts, textbausteine } from '$lib/db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { getDefect, updateDefectFields, listContactsForProject } from '$lib/db/defectQueries';
+import { listVorgaenge, addVorgang, listBriefVorlagen, getFirmaSettings } from '$lib/db/vorgangQueries';
 
 export const load: PageServerLoad = async ({ params }) => {
   const detail = await getDefect(params.projectId, params.defectId);
   if (!detail) error(404, 'Mangel nicht gefunden');
-  if (!db) return { ...detail, gewerke: [], contacts: [], textbausteine: [] };
+  if (!db) return { ...detail, gewerke: [], contacts: [], textbausteine: [], vorgaenge: [], briefVorlagen: [], firma: null };
 
-  const [gewerkeRows, contactsRows, textRows] = await Promise.all([
+  const [gewerkeRows, contactsRows, textRows, vorgaenge, briefVorlagen, firma] = await Promise.all([
     db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)),
     listContactsForProject(params.projectId),
-    db.select().from(textbausteine).orderBy(asc(textbausteine.sortOrder))
+    db.select().from(textbausteine).orderBy(asc(textbausteine.sortOrder)),
+    listVorgaenge(params.defectId),
+    listBriefVorlagen(params.projectId),
+    getFirmaSettings()
   ]);
 
-  return { ...detail, gewerke: gewerkeRows, contacts: contactsRows, textbausteine: textRows };
+  return {
+    ...detail,
+    gewerke: gewerkeRows,
+    contacts: contactsRows,
+    textbausteine: textRows,
+    vorgaenge,
+    briefVorlagen,
+    firma
+  };
 };
 
 const fieldsSchema = z.object({
@@ -28,6 +40,8 @@ const fieldsSchema = z.object({
   apartmentId: z.string().uuid().optional().or(z.literal('')),
   deadline: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().or(z.literal('')),
   followupDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().or(z.literal('')),
+  dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().or(z.literal('')),
+  rechtsgrundlage: z.string().max(120).optional().or(z.literal('')),
   priority: z.coerce.number().int().min(1).max(3).optional(),
   status: z.enum(['open', 'sent', 'acknowledged', 'resolved', 'accepted', 'rejected', 'reopened']).optional()
 });
@@ -35,6 +49,25 @@ const fieldsSchema = z.object({
 const photoLinkSchema = z.object({
   storagePath: z.string().min(3).max(300),
   caption: z.string().max(200).optional()
+});
+
+const vorgangSchema = z.object({
+  partei: z.enum(['AN', 'AG']),
+  status: z.enum([
+    'erfasst',
+    'angezeigt',
+    'nachfrist',
+    'klaerung',
+    'freigemeldet_NU',
+    'abgelehnt_NU',
+    'kontrolle_AG',
+    'erledigt',
+    'ersatzvornahme',
+    'notiz'
+  ]),
+  beschreibung: z.string().max(2000).optional().or(z.literal('')),
+  termin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().or(z.literal('')),
+  terminAntwort: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().or(z.literal(''))
 });
 
 export const actions: Actions = {
@@ -95,6 +128,63 @@ export const actions: Actions = {
 
     await db.delete(defectPhotos).where(eq(defectPhotos.id, photoId));
     try { await locals.supabase.storage.from('defect-photos').remove([photo.storagePath]); } catch (_e) { /* ignore */ }
+    return { ok: true };
+  },
+
+  addVorgang: async ({ request, params, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const parsed = vorgangSchema.safeParse(fd);
+    if (!parsed.success) return fail(400, { error: 'Ungültige Eingabe.' });
+
+    const row = await addVorgang({
+      defectId: params.defectId,
+      partei: parsed.data.partei,
+      status: parsed.data.status,
+      beschreibung: parsed.data.beschreibung || null,
+      termin: parsed.data.termin || null,
+      terminAntwort: parsed.data.terminAntwort || null,
+      createdBy: locals.user.id
+    });
+    return { ok: true, vorgangId: row?.id ?? null };
+  },
+
+  /**
+   * Mängelrüge anzeigen: erzeugt einen Vorgang AN (status='angezeigt'),
+   * setzt due_date und rechtsgrundlage am Mangel, hinterlegt das
+   * Document-Reference falls vorhanden. PDF-Generierung passiert client-seitig
+   * (siehe lib/pdf/maengelruege.ts) — der Server bekommt nur die Metadaten.
+   */
+  ruegeAnzeigen: async ({ request, params, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const schema = z.object({
+      contactId: z.string().uuid().optional().or(z.literal('')),
+      frist: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      rechtsgrundlage: z.string().max(120),
+      vorlageId: z.string().uuid().optional().or(z.literal('')),
+      documentId: z.string().max(120).optional()
+    });
+    const parsed = schema.safeParse(fd);
+    if (!parsed.success) return fail(400, { error: 'Ungültige Eingabe.' });
+
+    await updateDefectFields(params.projectId, params.defectId, locals.user.id, {
+      contactId: parsed.data.contactId || null,
+      dueDate: parsed.data.frist,
+      rechtsgrundlage: parsed.data.rechtsgrundlage,
+      status: 'sent'
+    });
+
+    await addVorgang({
+      defectId: params.defectId,
+      partei: 'AN',
+      status: 'angezeigt',
+      beschreibung: `Mängelrüge ${parsed.data.rechtsgrundlage} versendet, Frist ${parsed.data.frist}`,
+      termin: parsed.data.frist,
+      documentId: parsed.data.documentId ?? null,
+      createdBy: locals.user.id
+    });
+
     return { ok: true };
   }
 };

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
@@ -2,6 +2,8 @@
   import Icon from '$lib/components/Icon.svelte';
   import PhotoAnnotator from '$lib/components/PhotoAnnotator.svelte';
   import VoiceInput from '$lib/components/VoiceInput.svelte';
+  import VorgangTimeline from '$lib/components/VorgangTimeline.svelte';
+  import Sheet from '$lib/components/Sheet.svelte';
   import { uploadDefectPhoto, getSignedUrl } from '$lib/storage/photos';
   import { toast } from '$lib/components/Toast.svelte';
   import { confirm } from '$lib/components/ConfirmDialog.svelte';
@@ -12,6 +14,134 @@
 
   let { data } = $props();
   let parent = $derived(data);
+
+  // ----- Vorgang dialogs -----
+  let showVorgang = $state<{ partei: 'AN' | 'AG' } | null>(null);
+  let vStatus = $state<string>('notiz');
+  let vBeschreibung = $state('');
+  let vTermin = $state('');
+  let vTerminAntwort = $state('');
+
+  function openVorgang(partei: 'AN' | 'AG') {
+    showVorgang = { partei };
+    vStatus = partei === 'AN' ? 'angezeigt' : 'kontrolle_AG';
+    vBeschreibung = '';
+    vTermin = '';
+    vTerminAntwort = '';
+  }
+  async function submitVorgang() {
+    if (!showVorgang) return;
+    const fd = new FormData();
+    fd.append('partei', showVorgang.partei);
+    fd.append('status', vStatus);
+    fd.append('beschreibung', vBeschreibung);
+    fd.append('termin', vTermin);
+    fd.append('terminAntwort', vTerminAntwort);
+    const res = await fetch('?/addVorgang', { method: 'POST', body: fd });
+    if (res.ok) {
+      toast('Vorgang gespeichert.');
+      showVorgang = null;
+      await invalidateAll();
+    } else {
+      toast('Fehler.');
+    }
+  }
+
+  // ----- Mängelrüge dialog -----
+  let showRuege = $state(false);
+  let ruegeContactId = $state(data.defect.contactId ?? '');
+  let ruegeFrist = $state(addDaysIso(14));
+  let ruegeRechtsgrund = $state(data.defect.rechtsgrundlage ?? '§4 Abs.7 VOB/B');
+  let ruegeVorlageId = $state('');
+  let ruegeProcessing = $state(false);
+
+  function addDaysIso(days: number): string {
+    const d = new Date();
+    d.setDate(d.getDate() + days);
+    return d.toISOString().slice(0, 10);
+  }
+
+  async function generateRuege() {
+    if (ruegeProcessing) return;
+    ruegeProcessing = true;
+    try {
+      const { generateMaengelruege, downloadBlob, renderVorlage } = await import('$lib/pdf/maengelruege');
+      const empf = parent.contacts.find((c) => c.id === ruegeContactId) ?? parent.contact;
+      const vorlage = parent.briefVorlagen.find((v) => v.id === ruegeVorlageId)
+        ?? parent.briefVorlagen.find((v) => v.typ === 'mängelrüge_vorabnahme')
+        ?? null;
+      if (!vorlage) {
+        toast('Keine Brief-Vorlage gefunden.');
+        return;
+      }
+      const unterzeichner = parent.firma?.unterzeichner1 ?? 'Bauleitung';
+      const brieftext = renderVorlage(vorlage.vorlageText, {
+        projekt: parent.project.name,
+        frist: fmtDateDe(ruegeFrist),
+        rechtsgrundlage: ruegeRechtsgrund,
+        unterzeichner
+      });
+
+      const photoRes = await fetch(`/${parent.project.id}/maengel/${parent.defect.id}/photos.json`);
+      const photos = photoRes.ok ? ((await photoRes.json()) as { storagePath: string }[]) : [];
+
+      const blob = await generateMaengelruege({
+        projektName: parent.project.name,
+        empfaenger: {
+          company: empf?.company ?? null,
+          contactName: empf?.contactName ?? null,
+          address: empf?.address ?? null,
+          email: empf?.email ?? null
+        },
+        frist: ruegeFrist,
+        rechtsgrundlage: ruegeRechtsgrund,
+        brieftextRendered: brieftext,
+        unterzeichner,
+        defects: [
+          {
+            shortId: parent.defect.shortId,
+            title: parent.defect.title,
+            description: parent.defect.description,
+            apartmentLabel: parent.apartment ? `${parent.apartment.name}` : null,
+            planCropPath: parent.defect.planCropPath ?? null,
+            firstPhotoPath: photos[0]?.storagePath ?? null
+          }
+        ],
+        firma: {
+          name: parent.firma?.name ?? 'Hofmann Haus GmbH',
+          strasse: parent.firma?.strasse ?? '',
+          plzOrt: parent.firma?.plzOrt ?? '',
+          telefon: parent.firma?.telefon ?? null,
+          email: parent.firma?.email ?? null,
+          web: parent.firma?.web ?? null,
+          unterzeichner1: parent.firma?.unterzeichner1 ?? null,
+          unterzeichner2: parent.firma?.unterzeichner2 ?? null
+        }
+      });
+
+      downloadBlob(blob, `Maengelruege_${parent.defect.shortId ?? 'M'}_${ruegeFrist}.pdf`);
+
+      // Vorgang anlegen + Status setzen
+      const fd = new FormData();
+      fd.append('contactId', ruegeContactId);
+      fd.append('frist', ruegeFrist);
+      fd.append('rechtsgrundlage', ruegeRechtsgrund);
+      if (ruegeVorlageId) fd.append('vorlageId', ruegeVorlageId);
+      const res = await fetch('?/ruegeAnzeigen', { method: 'POST', body: fd });
+      if (res.ok) {
+        toast('Mängelrüge erstellt + Vorgang angelegt.');
+        showRuege = false;
+        await invalidateAll();
+      } else {
+        toast('PDF erstellt, aber Vorgang konnte nicht gespeichert werden.');
+      }
+    } catch (e) {
+      console.error(e);
+      toast('PDF-Generierung fehlgeschlagen.');
+    } finally {
+      ruegeProcessing = false;
+    }
+  }
 
   let title = $state(data.defect.title);
   let description = $state(data.defect.description ?? '');
@@ -151,6 +281,9 @@
     {#each (['acknowledged','resolved','accepted','rejected','reopened'] as const) as s}
       <button class="btn btn-ghost btn-sm" onclick={() => setStatus(s)}>{s}</button>
     {/each}
+    <button class="btn btn-primary btn-sm" onclick={() => (showRuege = true)} type="button">
+      <Icon name="send" size={12} /> Mängelrüge
+    </button>
   </div>
 
   <div class="field">
@@ -254,6 +387,12 @@
     </label>
   </div>
 
+  <h3 class="section-title">VOB-Vorgänge</h3>
+  <div class="vorgaenge-grid">
+    <VorgangTimeline partei="AN" vorgaenge={parent.vorgaenge} onAdd={() => openVorgang('AN')} />
+    <VorgangTimeline partei="AG" vorgaenge={parent.vorgaenge} onAdd={() => openVorgang('AG')} />
+  </div>
+
   <h3 class="section-title">Verlauf</h3>
   <div class="activity-feed">
     {#each parent.history as h (h.id)}
@@ -295,6 +434,109 @@
   </button>
 {/if}
 
+{#if showVorgang}
+  <Sheet
+    open={true}
+    title={`Vorgang ${showVorgang.partei === 'AN' ? 'AN' : 'AG'} hinzufügen`}
+    eyebrow="VOB-Vorgang"
+    ariaLabel="Vorgang hinzufügen"
+    onClose={() => (showVorgang = null)}
+  >
+    {#snippet body()}
+      <div class="field">
+        <label class="field-label" for="vstatus">Status</label>
+        <select id="vstatus" class="field-input" bind:value={vStatus}>
+          {#if showVorgang?.partei === 'AN'}
+            <option value="angezeigt">Angezeigt (Mängelrüge versendet)</option>
+            <option value="nachfrist">Nachfrist gesetzt</option>
+            <option value="klaerung">Klärung läuft</option>
+            <option value="freigemeldet_NU">Freigemeldet (NU)</option>
+            <option value="abgelehnt_NU">Abgelehnt (NU)</option>
+            <option value="ersatzvornahme">Ersatzvornahme</option>
+            <option value="notiz">Notiz</option>
+          {:else}
+            <option value="erfasst">Erfasst</option>
+            <option value="kontrolle_AG">Kontrolle</option>
+            <option value="erledigt">Erledigt</option>
+            <option value="notiz">Notiz</option>
+          {/if}
+        </select>
+      </div>
+      <div class="field">
+        <label class="field-label" for="vbeschr">Beschreibung</label>
+        <textarea id="vbeschr" class="field-input" rows="3" bind:value={vBeschreibung}></textarea>
+      </div>
+      <div class="field-row">
+        <div class="field">
+          <label class="field-label" for="vtermin">Termin / Frist</label>
+          <input id="vtermin" type="date" class="field-input" bind:value={vTermin} />
+        </div>
+        <div class="field">
+          <label class="field-label" for="vantwort">Antwort bis</label>
+          <input id="vantwort" type="date" class="field-input" bind:value={vTerminAntwort} />
+        </div>
+      </div>
+    {/snippet}
+    {#snippet foot()}
+      <button class="btn btn-primary btn-block" onclick={submitVorgang}>Speichern</button>
+    {/snippet}
+  </Sheet>
+{/if}
+
+{#if showRuege}
+  <Sheet
+    open={true}
+    title="Mängelrüge erstellen"
+    eyebrow="VOB-Schreiben"
+    ariaLabel="Mängelrüge erstellen"
+    onClose={() => (showRuege = false)}
+  >
+    {#snippet body()}
+      <div class="field">
+        <label class="field-label" for="ruege-c">Empfänger (Handwerker-Kontakt)</label>
+        <select id="ruege-c" class="field-input" bind:value={ruegeContactId}>
+          <option value="">— wählen —</option>
+          {#each parent.contacts as c (c.id)}
+            <option value={c.id}>{c.company} {c.contactName ? `· ${c.contactName}` : ''}</option>
+          {/each}
+        </select>
+      </div>
+      <div class="field-row">
+        <div class="field">
+          <label class="field-label" for="ruege-f">Frist zur Beseitigung</label>
+          <input id="ruege-f" type="date" class="field-input" bind:value={ruegeFrist} />
+        </div>
+        <div class="field">
+          <label class="field-label" for="ruege-r">Rechtsgrundlage</label>
+          <select id="ruege-r" class="field-input" bind:value={ruegeRechtsgrund}>
+            <option value="§4 Abs.7 VOB/B">§4 Abs.7 VOB/B (vor Abnahme)</option>
+            <option value="§13 Abs.5 Nr.1 VOB/B">§13 Abs.5 Nr.1 VOB/B (nach Abnahme)</option>
+            <option value="BGB §634 Nr.1">BGB §634 Nr.1</option>
+          </select>
+        </div>
+      </div>
+      <div class="field">
+        <label class="field-label" for="ruege-v">Brief-Vorlage</label>
+        <select id="ruege-v" class="field-input" bind:value={ruegeVorlageId}>
+          <option value="">— Standard nach Rechtsgrundlage —</option>
+          {#each parent.briefVorlagen as v (v.id)}
+            <option value={v.id}>{v.name}</option>
+          {/each}
+        </select>
+      </div>
+      <p class="field-hint" style="margin-top:8px">
+        Erzeugt ein PDF-Anschreiben mit Anlage „Mängelliste" und legt automatisch
+        einen Vorgang AN „angezeigt" mit der Frist an.
+      </p>
+    {/snippet}
+    {#snippet foot()}
+      <button class="btn btn-primary btn-block" onclick={generateRuege} disabled={ruegeProcessing || !ruegeContactId}>
+        <Icon name="send" size={14} /> {ruegeProcessing ? 'Generiere…' : 'PDF erzeugen + Vorgang anlegen'}
+      </button>
+    {/snippet}
+  </Sheet>
+{/if}
+
 <style>
   .back-link { display: inline-flex; align-items: center; gap: 6px; font-family: var(--mono); font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); padding: 0; margin-bottom: 12px; text-decoration: none; }
   .back-link:hover { color: var(--ink); }
@@ -304,6 +546,8 @@
   .defect-title-input:focus { border-bottom: 2px solid var(--red); outline: none; }
   .status-pill { font-family: var(--mono); font-size: 10px; font-weight: 700; text-transform: uppercase; padding: 4px 10px; border-radius: 999px; }
   .status-actions { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 16px; }
+  .vorgaenge-grid { display: grid; grid-template-columns: 1fr; gap: 12px; margin-bottom: 16px; }
+  @media (min-width: 768px) { .vorgaenge-grid { grid-template-columns: 1fr 1fr; } }
   .photo-tile { aspect-ratio: 1; border-radius: var(--r-md); overflow: hidden; background: var(--grey-soft); border: 1px solid var(--line); position: relative; }
   .photo-tile-img { width: 100%; height: 100%; padding: 0; border: none; cursor: zoom-in; }
   .photo-tile img { width: 100%; height: 100%; object-fit: cover; display: block; }

--- a/supabase/migrations/0010_defect_vorgaenge.sql
+++ b/supabase/migrations/0010_defect_vorgaenge.sql
@@ -1,0 +1,203 @@
+-- ============================================================
+-- 0010_defect_vorgaenge
+-- VOB-Workflow: Vorgangs-Historie pro Mangel (AN/AG-Spuren),
+-- Brief-Vorlagen für Mängelrüge / Nachfrist / Ersatzvornahme,
+-- Firma-Settings für PDF-Briefkopf.
+-- Idempotent + transactional.
+-- ============================================================
+
+BEGIN;
+
+-- ----- Enums -----
+DO $$ BEGIN
+  CREATE TYPE defect_party AS ENUM ('AN', 'AG');
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE defect_vorgang_status AS ENUM (
+    'erfasst',           -- 000 — neu erfasst
+    'angezeigt',         -- 020 — Mängelrüge versendet (Frist läuft)
+    'nachfrist',         -- 040 — Frist abgelaufen, Nachfrist gesetzt
+    'klaerung',          -- 070 — NU-Klärung läuft
+    'freigemeldet_NU',   -- 080 — NU meldet behoben
+    'abgelehnt_NU',      -- 085 — NU lehnt ab
+    'kontrolle_AG',      -- 090 — Bauleiter kontrolliert Behebung
+    'erledigt',          -- 100 — final geschlossen
+    'ersatzvornahme',    -- 200 — Ersatzvornahme angedroht/durchgeführt
+    'notiz'              -- 999 — interner Vermerk
+  );
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+-- ----- Vorgänge-Tabelle -----
+CREATE TABLE IF NOT EXISTS public.defect_vorgaenge (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  defect_id       uuid NOT NULL REFERENCES public.defects(id) ON DELETE CASCADE,
+  partei          defect_party NOT NULL,
+  status          defect_vorgang_status NOT NULL,
+  beschreibung    text,
+  termin          date,
+  termin_antwort  date,
+  document_id     text,
+  document_url    text,
+  created_by      uuid REFERENCES public.profiles(id),
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS dv_defect_partei_idx
+  ON public.defect_vorgaenge(defect_id, partei, created_at DESC);
+
+ALTER TABLE public.defect_vorgaenge ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "vorgaenge rw members" ON public.defect_vorgaenge;
+CREATE POLICY "vorgaenge rw members" ON public.defect_vorgaenge
+  FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.defects d
+    WHERE d.id = defect_vorgaenge.defect_id
+      AND public.is_project_member(d.project_id)
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.defects d
+    WHERE d.id = defect_vorgaenge.defect_id
+      AND public.is_project_member(d.project_id)
+  ));
+
+-- ----- defects ergänzen -----
+ALTER TABLE public.defects
+  ADD COLUMN IF NOT EXISTS due_date date,
+  ADD COLUMN IF NOT EXISTS rechtsgrundlage text;
+
+-- contact_id existiert bereits seit Phase 1, kein ADD nötig
+
+-- ----- Brief-Vorlagen -----
+CREATE TABLE IF NOT EXISTS public.brief_vorlagen (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id      uuid REFERENCES public.projects(id) ON DELETE CASCADE,
+  name            text NOT NULL,
+  typ             text NOT NULL,
+  rechtsgrundlage text,
+  vorlage_text    text NOT NULL,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.brief_vorlagen ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "brief vorlagen read all" ON public.brief_vorlagen;
+CREATE POLICY "brief vorlagen read all" ON public.brief_vorlagen
+  FOR SELECT TO authenticated
+  USING (project_id IS NULL OR public.is_project_member(project_id));
+
+DROP POLICY IF EXISTS "brief vorlagen write members" ON public.brief_vorlagen;
+CREATE POLICY "brief vorlagen write members" ON public.brief_vorlagen
+  FOR INSERT TO authenticated
+  WITH CHECK (project_id IS NULL OR public.is_project_member(project_id));
+
+DROP POLICY IF EXISTS "brief vorlagen update members" ON public.brief_vorlagen;
+CREATE POLICY "brief vorlagen update members" ON public.brief_vorlagen
+  FOR UPDATE TO authenticated
+  USING (project_id IS NULL OR public.is_project_member(project_id));
+
+-- ----- Firma-Settings (Briefkopf) -----
+CREATE TABLE IF NOT EXISTS public.firma_settings (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id              uuid,
+  name                text NOT NULL DEFAULT 'Hofmann Haus GmbH',
+  strasse             text NOT NULL DEFAULT 'Musterstraße 1',
+  plz_ort             text NOT NULL DEFAULT '74523 Schwäbisch Hall',
+  telefon             text,
+  email               text,
+  web                 text,
+  geschaeftsfuehrer   text,
+  ust_id              text,
+  bank                text,
+  iban                text,
+  bic                 text,
+  logo_path           text,
+  unterzeichner1      text,
+  unterzeichner2      text,
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.firma_settings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "firma read all" ON public.firma_settings;
+CREATE POLICY "firma read all" ON public.firma_settings
+  FOR SELECT TO authenticated USING (true);
+
+DROP POLICY IF EXISTS "firma write authenticated" ON public.firma_settings;
+CREATE POLICY "firma write authenticated" ON public.firma_settings
+  FOR INSERT TO authenticated WITH CHECK (true);
+
+DROP POLICY IF EXISTS "firma update authenticated" ON public.firma_settings;
+CREATE POLICY "firma update authenticated" ON public.firma_settings
+  FOR UPDATE TO authenticated USING (true);
+
+INSERT INTO public.firma_settings (name, strasse, plz_ort)
+  SELECT 'Hofmann Haus GmbH', 'Musterstraße 1', '74523 Schwäbisch Hall'
+  WHERE NOT EXISTS (SELECT 1 FROM public.firma_settings WHERE org_id IS NULL);
+
+-- ----- Default-Vorlagen (global, project_id NULL) -----
+DO $$
+DECLARE
+  v_template_text text;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.brief_vorlagen WHERE project_id IS NULL AND typ = 'mängelrüge_vorabnahme') THEN
+    v_template_text := E'Sehr geehrte Damen und Herren,\n\n'
+      || E'an der von Ihnen ausgeführten Leistung am Bauvorhaben '
+      || E'„{{projekt}}" haben sich die in der Anlage geschilderten '
+      || E'Restleistungen und/oder Mängel gezeigt.\n\n'
+      || E'Wir möchten Sie bitten, diese offenen Punkte spätestens bis '
+      || E'{{frist}} zu beseitigen und uns durch Unterzeichnung und '
+      || E'Rücksendung der in der Anlage beigefügten Bestätigung '
+      || E'entsprechend zu informieren.\n\n'
+      || E'Sollten Sie der Aufforderung zur Mängelbeseitigung innerhalb '
+      || E'der gesetzten Frist nicht nachkommen, behalten wir uns '
+      || E'rechtliche Schritte gem. {{rechtsgrundlage}} vor.\n\n'
+      || E'Mit freundlichen Grüßen\n{{unterzeichner}}';
+    INSERT INTO public.brief_vorlagen (project_id, name, typ, rechtsgrundlage, vorlage_text)
+    VALUES (NULL, 'Mängelrüge §4 Abs.7 VOB/B (vor Abnahme)', 'mängelrüge_vorabnahme', '§4 Abs.7 VOB/B', v_template_text);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM public.brief_vorlagen WHERE project_id IS NULL AND typ = 'mängelrüge_nachabnahme') THEN
+    v_template_text := E'Sehr geehrte Damen und Herren,\n\n'
+      || E'an der von Ihnen ausgeführten und abgenommenen Leistung am '
+      || E'Bauvorhaben „{{projekt}}" haben sich die in der Anlage '
+      || E'geschilderten Mängel gezeigt.\n\n'
+      || E'Wir fordern Sie hiermit gem. §13 Abs.5 Nr.1 VOB/B zur '
+      || E'Beseitigung dieser Mängel innerhalb der Gewährleistungsfrist '
+      || E'auf. Frist zur Beseitigung: {{frist}}.\n\n'
+      || E'Mit freundlichen Grüßen\n{{unterzeichner}}';
+    INSERT INTO public.brief_vorlagen (project_id, name, typ, rechtsgrundlage, vorlage_text)
+    VALUES (NULL, 'Mängelrüge §13 Abs.5 Nr.1 VOB/B (nach Abnahme)', 'mängelrüge_nachabnahme', '§13 Abs.5 Nr.1 VOB/B', v_template_text);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM public.brief_vorlagen WHERE project_id IS NULL AND typ = 'nachfrist') THEN
+    v_template_text := E'Sehr geehrte Damen und Herren,\n\n'
+      || E'mit unserem Schreiben vom {{datum_anzeige}} hatten wir Sie '
+      || E'aufgefordert, die in der Anlage genannten Mängel bis zum '
+      || E'{{frist_alt}} zu beseitigen. Eine Mängelbeseitigung ist '
+      || E'innerhalb der gesetzten Frist nicht erfolgt.\n\n'
+      || E'Hiermit setzen wir Ihnen gem. {{rechtsgrundlage}} eine '
+      || E'angemessene Nachfrist bis zum {{frist}}.\n\n'
+      || E'Sollten Sie auch innerhalb dieser Nachfrist die Mängel nicht '
+      || E'beseitigen, drohen wir Ihnen hiermit die Ersatzvornahme auf '
+      || E'Ihre Kosten an.\n\n'
+      || E'Mit freundlichen Grüßen\n{{unterzeichner}}';
+    INSERT INTO public.brief_vorlagen (project_id, name, typ, rechtsgrundlage, vorlage_text)
+    VALUES (NULL, 'Nachfrist mit Ersatzvornahme-Androhung', 'nachfrist', '§4 Abs.7 VOB/B', v_template_text);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM public.brief_vorlagen WHERE project_id IS NULL AND typ = 'freimeldung_bestaetigung') THEN
+    v_template_text := E'Sehr geehrte Damen und Herren,\n\n'
+      || E'mit Ihrer Rückmeldung vom {{datum_freimeldung}} haben Sie '
+      || E'uns mitgeteilt, dass die in der Anlage genannten Mängel '
+      || E'beseitigt sind.\n\n'
+      || E'Hiermit bestätigen wir die Kontrolle vor Ort und das '
+      || E'Erledigt-Setzen dieser Mängel im Mängelmanagement-System.\n\n'
+      || E'Mit freundlichen Grüßen\n{{unterzeichner}}';
+    INSERT INTO public.brief_vorlagen (project_id, name, typ, rechtsgrundlage, vorlage_text)
+    VALUES (NULL, 'Freimeldungs-Bestätigung', 'freimeldung_bestaetigung', NULL, v_template_text);
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## ⚠️ MIGRATION — Laurenz muss SQL manuell im Supabase SQL Editor ausführen, bevor Merge

```
supabase/migrations/0010_defect_vorgaenge.sql
```

**Migration 0010 benötigt — Laurenz muss SQL manuell in Supabase laufen lassen vor Merge.**

Idempotent + transactional (`BEGIN`/`COMMIT`, `DO $$ … duplicate_object`,
`IF NOT EXISTS`). Bestehende Mängel bleiben funktional, neue Felder sind
NULL.

Self-Merge ist **nicht zulässig**.

## Was es macht

Das Herzstück der docma-Parität. Aus dem Mangel-Detail heraus kann der
Bauleiter ab sofort:

1. Per **„Mängelrüge"-Button** ein PDF-Anschreiben generieren mit:
   - Hofmann-Briefkopf (aus `firma_settings`)
   - Empfänger-Adresse aus Kontakten
   - Brieftext aus Vorlage (Platzhalter wie `{{frist}}`,
     `{{rechtsgrundlage}}`, `{{unterzeichner}}` werden gerendert)
   - Anlage „Mängelliste" mit Plan-Crop-Vorschau pro Mangel
   - Bestätigungs-Block unten („Datum, Unterschrift Auftragnehmer")
2. **Vorgangs-Historie pro Mangel** in zwei Spuren (AN / AG) pflegen.
   Jede Statusänderung erzeugt einen `defect_vorgaenge`-Eintrag.
   Letzter Eintrag pro Spur = aktueller Status (für Liste/Filter).
3. **Frist-Tracking**: Beim Anzeigen wird `defects.due_date` gesetzt.
   Filter „überfällig" (Liste) zeigt Mängel mit `due_date < heute`
   und letzter AN-Status `angezeigt`/`nachfrist`.

## Datenmodell (Migration 0010)

| Tabelle/Feld | Zweck |
|---|---|
| `defect_party` enum | `AN` / `AG` |
| `defect_vorgang_status` enum | 10 Status-Codes (erfasst → erledigt + ersatzvornahme + notiz) |
| `defect_vorgaenge` | Eine Zeile pro Statuswechsel: defect_id, partei, status, beschreibung, termin, termin_antwort, document_id/url |
| `brief_vorlagen` | Globale + Projekt-spezifische Schreibvorlagen mit Platzhaltern |
| `firma_settings` | Briefkopf-Daten (name, strasse, plz_ort, telefon, email, unterzeichner1/2, …) |
| `defects.due_date` | Erledigungsfrist aus Mängelrüge |
| `defects.rechtsgrundlage` | Last gewählte Rechtsgrundlage (z.B. „§4 Abs.7 VOB/B") |

RLS: alle neuen Tabellen `is_project_member()` oder `authenticated read`.

Default-Seed:
- Hofmann Haus GmbH als Default-Firma (kann user editieren)
- 4 Brief-Vorlagen: Mängelrüge §4 Abs.7 (vor Abnahme), §13 Abs.5 (nach Abnahme), Nachfrist + Ersatzvornahme-Androhung, Freimeldungs-Bestätigung

## Diff-Übersicht (8 Files)

| File | Was |
|---|---|
| `supabase/migrations/0010_defect_vorgaenge.sql` | NEU — komplette Migration |
| `src/lib/db/schema.ts` | + `defectVorgaenge`, `briefVorlagen`, `firmaSettings`, defects ergänzt |
| `src/lib/db/vorgangTypes.ts` | NEU — DB-freie Types/Labels (browser-safe) |
| `src/lib/db/vorgangQueries.ts` | NEU — Server-Queries |
| `src/lib/components/VorgangTimeline.svelte` | NEU — wiederverwendbare Timeline pro Spur |
| `src/lib/pdf/maengelruege.ts` | NEU — PDF-Generator (pdf-lib) |
| `src/routes/(app)/[projectId]/maengel/[defectId]/+page.{svelte,server.ts}` | + Vorgänge-Section, Sheet-Dialoge, ruegeAnzeigen-Action |
| `src/routes/(app)/[projectId]/maengel/+page.server.ts` | + vorgangsByProject-Aggregat im Load |

## Architektur-Entscheidungen (siehe DECISIONS)

**Warum Types-File separat?** `vorgangQueries.ts` importiert das Drizzle-
Schema, das `postgres-js` indirekt zieht. Ein Browser-Import würde Vite-
Build kaputt machen (postgres-js ist node-only). Lösung: Labels/Types in
`vorgangTypes.ts`, das ist DB-frei und überall importierbar.

**Warum nicht Server-Action für PDF?** PDF wird browser-side mit
`pdf-lib` generiert (gleiche Library wie defectReport.ts) → kein
Server-CPU-Load, einfacheres Caching, direkter Download via Blob.
Server-Action `ruegeAnzeigen` wird **nach** PDF-Generierung gerufen,
um Vorgang + due_date konsistent zu setzen.

## Self-Review

- [x] Kein `console.log` außer 1 `console.error` für PDF-Fail-Pfad
- [x] Migration: alle DDL in BEGIN/COMMIT, `IF NOT EXISTS`,
      `DO $$ … duplicate_object`-Catch für Enums
- [x] RLS: alle neuen Tabellen `is_project_member()`-gesichert
- [x] Edge-Case: `firma_settings` leer → PDF nutzt Fallback-Default
- [x] Edge-Case: keine Vorlage gewählt → fällt auf
      `mängelrüge_vorabnahme` zurück
- [x] Edge-Case: kein Empfänger → PDF-Button disabled
- [x] type-check 0 errors · Tests 17/17 grün · Build clean
- [x] Diff: 8 Files (Soft-Limit), ~750 LoC inkl. Migration

## Test plan (nach Migration-Run)

- [x] `pnpm check` → 0 errors
- [x] `pnpm test` → 17/17 grün
- [x] `pnpm build` → OK
- [ ] Live nach Merge:
  - [ ] Mangel öffnen → zwei Vorgangs-Timelines sichtbar (AN/AG)
  - [ ] Klick „Vorgang AN" → Sheet mit Status-Dropdown
  - [ ] Speichern → Eintrag erscheint sofort (invalidate)
  - [ ] Klick „Mängelrüge" → Sheet mit Empfänger/Frist/Vorlage
  - [ ] PDF erzeugen → Download startet, Vorgang AN „angezeigt"
        wird angelegt, Mangel-Status wechselt auf „sent",
        `due_date` ist gesetzt
  - [ ] PDF prüfen: Briefkopf, Empfänger, Brieftext, Anlage mit
        Plan-Crop, Bestätigungs-Block

## Out-of-scope (Phase 5+)

- Multi-Mangel-Sammelrüge (kommt mit PR #18 → Sammelbericht + Bulk-Action)
- QR-Code im PDF (kommt mit PR #19 → Public-Freimeldung)
- Edit/Delete einzelner Vorgänge (heute nur Append; ungewöhnlich für
  Audit-Logs aber kann bei Bedarf nachgereicht werden)
- Briefkopf-Bearbeitung im UI (heute nur per SQL/Supabase-Dashboard)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_