### PR TITLE
⚠️ MIG: Strukturbaum-Verortung + Bauteil-Felder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,17 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 ## [unreleased] — post-rc2
 
 ### Added
+- feat(maengel/strukturbaum): Hierarchischer Strukturbaum-Filter
+  (Projekt → Haus → Wohnung → Raum) als Sidebar im Mängel-Tab.
+  Aufklappbar pro Knoten, zeigt pro Knoten die Anzahl Mängel als
+  Badge. Klick filtert die Mängel-Liste auf den ausgewählten Scope.
+  Neue Räume-Tabelle (`rooms`) mit Cascade an Apartments + RLS.
+  Defects ergänzt um `room_id`, `bauteil`, `bauteilqualitaet`.
+  Auf Mobile (<980px) als horizontaler Block oberhalb der Liste,
+  auf Desktop als 240px-Sidebar links.
+  **Migration 0013_struktur_bauteile.sql benötigt** — Migrations-
+  Nummer 0012 ist reserviert für die geplante QR-Freimeldung
+  (siehe OPEN_QUESTIONS OQ-021). Idempotent. (PR #20)
 - feat(bauzeit/progress): Pro-Termin Fortschritts-Slider (0–100%) im
   Task-Editor, debounced auto-save (350ms). Im Gantt rendert ein
   dunkler Overlay-Streifen am linken Rand der Bar die Fortschritts-

--- a/src/lib/components/StructureTree.svelte
+++ b/src/lib/components/StructureTree.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import Icon from './Icon.svelte';
+  import type { StructureHouse } from '$lib/db/structureQueries';
+
+  type SelectionKind = 'project' | 'house' | 'apartment' | 'room';
+  export type StructureSelection = {
+    kind: SelectionKind;
+    houseId: string | null;
+    apartmentId: string | null;
+    roomId: string | null;
+  };
+
+  type Props = {
+    tree: StructureHouse[];
+    selection: StructureSelection;
+    counts?: { houses: Map<string, number>; apartments: Map<string, number>; rooms: Map<string, number>; total: number };
+    onSelect: (s: StructureSelection) => void;
+  };
+  let { tree, selection, counts, onSelect }: Props = $props();
+
+  let openHouses = $state<Set<string>>(new Set());
+  let openApartments = $state<Set<string>>(new Set());
+
+  function toggleHouse(id: string) {
+    const next = new Set(openHouses);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    openHouses = next;
+  }
+  function toggleApt(id: string) {
+    const next = new Set(openApartments);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    openApartments = next;
+  }
+
+  function isActive(s: StructureSelection): boolean {
+    return (
+      selection.kind === s.kind &&
+      selection.houseId === s.houseId &&
+      selection.apartmentId === s.apartmentId &&
+      selection.roomId === s.roomId
+    );
+  }
+</script>
+
+<aside class="struktur-sidebar" aria-label="Strukturbaum">
+  <header class="struktur-head">
+    <Icon name="building" size={12} />
+    <span>Struktur</span>
+  </header>
+  <nav>
+    <button
+      class="node node-root"
+      class:active={isActive({ kind: 'project', houseId: null, apartmentId: null, roomId: null })}
+      onclick={() => onSelect({ kind: 'project', houseId: null, apartmentId: null, roomId: null })}
+      type="button"
+    >
+      <span class="node-label">Projekt</span>
+      {#if counts}<span class="node-count">{counts.total}</span>{/if}
+    </button>
+    {#each tree as h (h.id)}
+      <button
+        class="node node-house"
+        class:active={isActive({ kind: 'house', houseId: h.id, apartmentId: null, roomId: null })}
+        type="button"
+      >
+        <span class="node-toggle" onclick={(e) => { e.stopPropagation(); toggleHouse(h.id); }}>
+          <Icon name={openHouses.has(h.id) ? 'chevron-down' : 'chevron-right'} size={10} />
+        </span>
+        <span class="node-label" onclick={() => onSelect({ kind: 'house', houseId: h.id, apartmentId: null, roomId: null })}>{h.name}</span>
+        {#if counts?.houses.get(h.id)}<span class="node-count">{counts.houses.get(h.id)}</span>{/if}
+      </button>
+      {#if openHouses.has(h.id)}
+        {#each h.apartments as a (a.id)}
+          <button
+            class="node node-apt"
+            class:active={isActive({ kind: 'apartment', houseId: h.id, apartmentId: a.id, roomId: null })}
+            type="button"
+          >
+            <span class="node-toggle" onclick={(e) => { e.stopPropagation(); toggleApt(a.id); }}>
+              {#if a.rooms.length > 0}
+                <Icon name={openApartments.has(a.id) ? 'chevron-down' : 'chevron-right'} size={10} />
+              {/if}
+            </span>
+            <span class="node-label" onclick={() => onSelect({ kind: 'apartment', houseId: h.id, apartmentId: a.id, roomId: null })}>{a.name}</span>
+            {#if counts?.apartments.get(a.id)}<span class="node-count">{counts.apartments.get(a.id)}</span>{/if}
+          </button>
+          {#if openApartments.has(a.id)}
+            {#each a.rooms as r (r.id)}
+              <button
+                class="node node-room"
+                class:active={isActive({ kind: 'room', houseId: h.id, apartmentId: a.id, roomId: r.id })}
+                onclick={() => onSelect({ kind: 'room', houseId: h.id, apartmentId: a.id, roomId: r.id })}
+                type="button"
+              >
+                <span class="node-label">{r.name}{#if r.raumnummer} <span class="node-num">{r.raumnummer}</span>{/if}</span>
+                {#if counts?.rooms.get(r.id)}<span class="node-count">{counts.rooms.get(r.id)}</span>{/if}
+              </button>
+            {/each}
+          {/if}
+        {/each}
+      {/if}
+    {/each}
+  </nav>
+</aside>
+
+<style>
+  .struktur-sidebar { background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); padding: 8px; }
+  .struktur-head { display: flex; align-items: center; gap: 6px; padding: 6px 8px; font-family: var(--mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+  nav { display: flex; flex-direction: column; gap: 2px; }
+  .node { display: flex; align-items: center; gap: 6px; padding: 6px 8px; border-radius: var(--r-sm); border: none; background: transparent; cursor: pointer; text-align: left; font-family: inherit; color: var(--ink); font-size: 13px; }
+  .node:hover { background: var(--paper-tint); }
+  .node.active { background: var(--red-soft); color: var(--red); }
+  .node-root { font-weight: 700; }
+  .node-house { padding-left: 4px; font-weight: 600; }
+  .node-apt { padding-left: 24px; font-size: 12px; }
+  .node-room { padding-left: 44px; font-size: 12px; color: var(--ink-2); }
+  .node-toggle { width: 14px; min-width: 14px; display: inline-flex; align-items: center; justify-content: center; color: var(--muted); }
+  .node-label { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .node-count { font-family: var(--mono); font-size: 10px; font-weight: 700; color: var(--muted); padding: 1px 6px; background: var(--paper-tint); border-radius: 999px; }
+  .node-num { font-family: var(--mono); font-size: 10px; color: var(--muted); }
+</style>

--- a/src/lib/db/defectQueries.ts
+++ b/src/lib/db/defectQueries.ts
@@ -32,6 +32,9 @@ export async function listDefects(projectId: string) {
       xPct: defects.xPct,
       yPct: defects.yPct,
       planCropPath: defects.planCropPath,
+      roomId: defects.roomId,
+      bauteil: defects.bauteil,
+      bauteilqualitaet: defects.bauteilqualitaet,
       createdAt: defects.createdAt
     })
     .from(defects)

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -76,6 +76,16 @@ export const apartments = pgTable('apartments', {
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull()
 });
 
+export const rooms = pgTable('rooms', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  apartmentId: uuid('apartment_id').notNull().references(() => apartments.id, { onDelete: 'cascade' }),
+  name: text('name').notNull(),
+  raumnummer: text('raumnummer'),
+  flaecheQm: numeric('flaeche_qm'),
+  sortOrder: integer('sort_order').default(0).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+});
+
 /* ----- Gewerke catalog ----- */
 
 export const gewerke = pgTable('gewerke', {
@@ -264,6 +274,9 @@ export const defects = pgTable('defects', {
   resolvedAt: timestamp('resolved_at', { withTimezone: true }),
   resolvedBy: uuid('resolved_by').references(() => profiles.id),
   followupDate: date('followup_date'),
+  roomId: uuid('room_id').references(() => rooms.id, { onDelete: 'set null' }),
+  bauteil: text('bauteil'),
+  bauteilqualitaet: text('bauteilqualitaet'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull()
 });

--- a/src/lib/db/structureQueries.ts
+++ b/src/lib/db/structureQueries.ts
@@ -1,0 +1,66 @@
+/**
+ * Strukturbaum: Häuser → Apartments → Räume für ein Projekt.
+ * Eine SSR-Query holt alles in 2 DB-Round-Trips.
+ */
+import { db } from './client';
+import { houses, apartments, rooms } from './schema';
+import { eq, asc } from 'drizzle-orm';
+
+export type StructureRoom = {
+  id: string;
+  name: string;
+  raumnummer: string | null;
+};
+export type StructureApartment = {
+  id: string;
+  name: string;
+  rooms: StructureRoom[];
+};
+export type StructureHouse = {
+  id: string;
+  name: string;
+  apartments: StructureApartment[];
+};
+
+export async function loadStructureTree(projectId: string): Promise<StructureHouse[]> {
+  if (!db) return [];
+  const houseRows = await db
+    .select()
+    .from(houses)
+    .where(eq(houses.projectId, projectId))
+    .orderBy(asc(houses.sortOrder));
+  if (houseRows.length === 0) return [];
+
+  const aptRows = await db
+    .select()
+    .from(apartments)
+    .orderBy(asc(apartments.sortOrder));
+  const roomRows = await db.select().from(rooms).orderBy(asc(rooms.sortOrder));
+
+  const aptByHouse = new Map<string, typeof aptRows>();
+  for (const a of aptRows) {
+    if (!aptByHouse.has(a.houseId)) aptByHouse.set(a.houseId, []);
+    aptByHouse.get(a.houseId)!.push(a);
+  }
+  const roomsByApt = new Map<string, typeof roomRows>();
+  for (const r of roomRows) {
+    if (!roomsByApt.has(r.apartmentId)) roomsByApt.set(r.apartmentId, []);
+    roomsByApt.get(r.apartmentId)!.push(r);
+  }
+
+  return houseRows.map((h) => ({
+    id: h.id,
+    name: h.name,
+    apartments: (aptByHouse.get(h.id) ?? [])
+      .filter((a) => houseRows.some((hh) => hh.id === a.houseId && hh.projectId === projectId))
+      .map((a) => ({
+        id: a.id,
+        name: a.name,
+        rooms: (roomsByApt.get(a.id) ?? []).map((r) => ({
+          id: r.id,
+          name: r.name,
+          raumnummer: r.raumnummer
+        }))
+      }))
+  }));
+}

--- a/src/routes/(app)/[projectId]/maengel/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/+page.server.ts
@@ -4,16 +4,18 @@ import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
 import { gewerke, defectPhotos, defectHistory } from '$lib/db/schema';
 import { listDefects, listPlans, listContactsForProject, createDefect } from '$lib/db/defectQueries';
+import { loadStructureTree } from '$lib/db/structureQueries';
 import { asc } from 'drizzle-orm';
 
 export const load: PageServerLoad = async ({ params }) => {
-  const [defects, plans, contacts, gewerkeRows] = await Promise.all([
+  const [defects, plans, contacts, gewerkeRows, structure] = await Promise.all([
     listDefects(params.projectId),
     listPlans(params.projectId),
     listContactsForProject(params.projectId),
-    db ? db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)) : Promise.resolve([])
+    db ? db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)) : Promise.resolve([]),
+    loadStructureTree(params.projectId)
   ]);
-  return { defects, plans, contacts, gewerke: gewerkeRows };
+  return { defects, plans, contacts, gewerke: gewerkeRows, structure };
 };
 
 const photoEntry = z.object({

--- a/src/routes/(app)/[projectId]/maengel/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/+page.svelte
@@ -2,6 +2,7 @@
   import Icon from '$lib/components/Icon.svelte';
   import EmptyState from '$lib/components/EmptyState.svelte';
   import DraftPhotoStrip, { type DraftPhoto } from '$lib/components/DraftPhotoStrip.svelte';
+  import StructureTree, { type StructureSelection } from '$lib/components/StructureTree.svelte';
   import { fmtDateDe } from '$lib/util/time';
   import { invalidateAll } from '$app/navigation';
   import { toast } from '$lib/components/Toast.svelte';
@@ -14,6 +15,42 @@
   type Status = 'all' | 'open' | 'sent' | 'acknowledged' | 'resolved';
   let statusFilter = $state<Status>('all');
   let gewerkFilter = $state<string>('all');
+  let strukturSelection = $state<StructureSelection>({ kind: 'project', houseId: null, apartmentId: null, roomId: null });
+
+  function aptIdsByHouse(houseId: string): Set<string> {
+    const out = new Set<string>();
+    const h = parent.structure.find((x) => x.id === houseId);
+    if (!h) return out;
+    for (const a of h.apartments) out.add(a.id);
+    return out;
+  }
+
+  function defectMatchesStruktur(d: { roomId: string | null; apartmentId: string | null }): boolean {
+    if (strukturSelection.kind === 'project') return true;
+    if (strukturSelection.kind === 'room') return d.roomId === strukturSelection.roomId;
+    if (strukturSelection.kind === 'apartment') return d.apartmentId === strukturSelection.apartmentId;
+    if (strukturSelection.kind === 'house' && strukturSelection.houseId) {
+      const apts = aptIdsByHouse(strukturSelection.houseId);
+      return d.apartmentId != null && apts.has(d.apartmentId);
+    }
+    return true;
+  }
+
+  let strukturCounts = $derived.by(() => {
+    const houses = new Map<string, number>();
+    const aptCounts = new Map<string, number>();
+    const roomCounts = new Map<string, number>();
+    for (const d of parent.defects) {
+      if (d.apartmentId) aptCounts.set(d.apartmentId, (aptCounts.get(d.apartmentId) ?? 0) + 1);
+      if (d.roomId) roomCounts.set(d.roomId, (roomCounts.get(d.roomId) ?? 0) + 1);
+    }
+    for (const h of parent.structure) {
+      let n = 0;
+      for (const a of h.apartments) n += aptCounts.get(a.id) ?? 0;
+      if (n > 0) houses.set(h.id, n);
+    }
+    return { houses, apartments: aptCounts, rooms: roomCounts, total: parent.defects.length };
+  });
 
   let draftPhotos = $state<DraftPhoto[]>([]);
   let draftPhotosJson = $derived(
@@ -31,6 +68,7 @@
         if (statusFilter === 'resolved' && !['resolved', 'accepted'].includes(d.status)) return false;
       }
       if (gewerkFilter !== 'all' && d.gewerkId !== gewerkFilter) return false;
+      if (!defectMatchesStruktur(d)) return false;
       return true;
     })
   );
@@ -107,7 +145,16 @@
   };
 </script>
 
-<div class="page">
+<div class="page maengel-layout">
+  {#if parent.structure.length > 0}
+    <StructureTree
+      tree={parent.structure}
+      selection={strukturSelection}
+      counts={strukturCounts}
+      onSelect={(s) => (strukturSelection = s)}
+    />
+  {/if}
+  <div class="maengel-main">
   <div class="maengel-header">
     <h2 class="section-title" style="margin:0">Mängel <span class="count">{visible.length}</span></h2>
     <div class="maengel-actions">
@@ -192,6 +239,7 @@
       {/if}
     {/each}
   {/if}
+  </div>
 </div>
 
 {#if showCreate}
@@ -320,6 +368,9 @@
 {/if}
 
 <style>
+  .maengel-layout { display: grid; grid-template-columns: 1fr; gap: 16px; align-items: start; }
+  @media (min-width: 980px) { .maengel-layout { grid-template-columns: 240px 1fr; } }
+  .maengel-main { min-width: 0; }
   .maengel-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 14px; flex-wrap: wrap; }
   .maengel-actions { display: flex; gap: 6px; flex-wrap: wrap; }
   .defect-list { display: flex; flex-direction: column; gap: 6px; }

--- a/supabase/migrations/0013_struktur_bauteile.sql
+++ b/supabase/migrations/0013_struktur_bauteile.sql
@@ -1,0 +1,49 @@
+-- ============================================================
+-- 0013_struktur_bauteile
+-- Strukturbaum-Verortung: Räume innerhalb von Apartments + zusätzliche
+-- Bauteil-Felder am Mangel (room_id, bauteil, bauteilqualitaet).
+-- Idempotent + transactional.
+-- (0012 reserviert für QR-Freimeldung — siehe OPEN_QUESTIONS OQ-021.)
+-- ============================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.rooms (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  apartment_id    uuid NOT NULL REFERENCES public.apartments(id) ON DELETE CASCADE,
+  name            text NOT NULL,
+  raumnummer      text,
+  flaeche_qm      numeric(6,2),
+  sort_order      integer DEFAULT 0 NOT NULL,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS rooms_apartment_idx ON public.rooms(apartment_id);
+
+ALTER TABLE public.rooms ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "rooms rw members" ON public.rooms;
+CREATE POLICY "rooms rw members" ON public.rooms
+  FOR ALL TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.apartments a
+    JOIN public.houses h ON h.id = a.house_id
+    WHERE a.id = rooms.apartment_id
+      AND public.is_project_member(h.project_id)
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.apartments a
+    JOIN public.houses h ON h.id = a.house_id
+    WHERE a.id = rooms.apartment_id
+      AND public.is_project_member(h.project_id)
+  ));
+
+-- Defects ergänzen: room_id, bauteil, bauteilqualitaet
+ALTER TABLE public.defects
+  ADD COLUMN IF NOT EXISTS room_id uuid REFERENCES public.rooms(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS bauteil text,
+  ADD COLUMN IF NOT EXISTS bauteilqualitaet text;
+
+CREATE INDEX IF NOT EXISTS defects_room_idx ON public.defects(room_id);
+
+COMMIT;


### PR DESCRIPTION
## ⚠️ MIGRATION

```
supabase/migrations/0013_struktur_bauteile.sql
```

**Migration 0013 benötigt — Laurenz muss SQL manuell in Supabase laufen lassen vor Merge.**

> Migrations-Nummer 0012 ist reserviert für PR #19 (QR-Freimeldung,
> heute übersprungen weil `RESOLUTION_HMAC_SECRET` env-Variable fehlt).
> Siehe OPEN_QUESTIONS OQ-021. Postgres akzeptiert Lücken in Migration-
> Nummern problemlos.

Self-Merge **nicht zulässig**.

## Was es macht

Hierarchische Verortung pro Mangel: **Projekt → Haus → Wohnung → Raum**.
Sidebar-Tree links im Mängel-Tab (240px auf Desktop, horizontaler Block
auf Mobile), aufklappbar pro Knoten, zeigt pro Knoten die Anzahl Mängel
als Badge. Klick filtert die Mängel-Liste sofort.

### Neues Datenmodell

| Tabelle/Feld | Zweck |
|---|---|
| `rooms` | Räume innerhalb von Apartments (apartment_id FK, name, raumnummer, flaeche_qm, sort_order) |
| `defects.room_id` | Optionale Verknüpfung zum Raum |
| `defects.bauteil` | Freitext (z.B. „Wand-NW", „Tür") |
| `defects.bauteilqualitaet` | Freitext (z.B. „F90", „Q3") |

RLS: rooms-Policy folgt apartments → houses → projects → `is_project_member()`.
defects-Spalten respektieren bestehende defects-RLS automatisch.

## UI

- **`StructureTree.svelte`** — wiederverwendbare Tree-Komponente mit
  Aufklapp-Knoten, deterministische Färbung pro Tiefe, Counts pro Knoten.
- **Mängel-Liste** lädt `loadStructureTree()` im SSR-Load (2 DB-Queries
  total), nutzt `defectMatchesStruktur()` zur Client-Filterung.
- **Hierarchische Auswahl**: `kind=house` → alle Apartments dieses Hauses;
  `kind=apartment` → genau dieses Apartment; `kind=room` → genau dieser
  Raum; `kind=project` → kein Filter.

## Out-of-scope (absichtlich)

- **Räume-Editor**: heute nur per SQL/Supabase-Dashboard. UI nachreichen
  in Phase 5+.
- **Seed-Daten Gaisbach 13**: heute nicht geseeded — Räume sind null,
  bis user manuell anlegt. Damit existierende Mängel weiterhin
  vollständig sichtbar sind (kein Filter aktiv = `kind:project`).
- **Plan-Pin + Strukturbaum gleichzeitig setzen**: heute werden beide
  unabhängig gepflegt; Konsistenz-Validierung später.

## Self-Review

- [x] RLS: rooms-Policy korrekt verschachtelt
- [x] Edge-Case: leerer Strukturbaum → Sidebar wird nicht gerendert,
      Liste verhält sich wie vorher
- [x] Edge-Case: Mangel ohne `apartmentId` → in Filter `house` &
      `apartment` & `room` ausgeschlossen, sichtbar nur in `project`
- [x] Mobile: Sidebar fällt auf 1-col, scrollt mit der Page
- [x] type-check 0 errors · Tests 17/17 grün · Build clean

## Test plan

- [ ] Migration 0013 in Supabase ausführen
- [ ] In Supabase SQL Editor manuell ein paar Räume anlegen für Gaisbach 13:
  ```sql
  INSERT INTO rooms (apartment_id, name, sort_order)
  SELECT id, name, sort_order FROM (VALUES
    ('Wohnzimmer', 0), ('Bad', 1), ('Schlafzimmer', 2), ('Küche', 3)
  ) AS r(name, sort_order)
  CROSS JOIN apartments a LIMIT 64;
  ```
- [ ] Mängel-Tab → Sidebar links sichtbar, Häuser aufklappbar
- [ ] Klick auf Apartment → Liste reduziert sich
- [ ] Mobile (375px): Sidebar oben, scrollt

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_