### PR TITLE
⚠️ MIG: Mangel-Templates für 1-Klick-Erfassung

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,18 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 ## [unreleased] — post-rc2
 
 ### Added
+- feat(maengel/templates): Mangel-Vorlagen für 1-Klick-Erfassung.
+  Im Mangel-Anlegen-Sheet ist eine neue Combobox „Mangel-Template",
+  Auswahl füllt Title/Beschreibung/Gewerk/Frist/Priorität vor.
+  `useCount` wird beim Submit hochgezählt — häufig verwendete
+  Templates erscheinen oben in der Liste.
+  **Migration 0014_mangel_templates.sql benötigt** — fügt
+  `defect_templates`-Tabelle mit RLS hinzu und seedet 30 Standard-
+  Vorlagen aus dem Hofmann-Portfolio (Maler/Fliesenleger/Elektro/
+  Sanitär/Trockenbau/Parkett/Türen/Fenster/Rohbau/Außen).
+  Idempotent (Name-basierter NOT EXISTS-Guard pro Template).
+  Verwendet existierende Gewerk-IDs aus dem Seed (Migration 0000),
+  setzt gewerk_id NULL falls Gewerk fehlt. (PR #21)
 - feat(bauzeit/progress): Pro-Termin Fortschritts-Slider (0–100%) im
   Task-Editor, debounced auto-save (350ms). Im Gantt rendert ein
   dunkler Overlay-Streifen am linken Rand der Bar die Fortschritts-

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -338,6 +338,22 @@ export const textbausteine = pgTable('textbausteine', {
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 
+/* ----- Defect-Templates (1-Klick-Erfassung) ----- */
+
+export const defectTemplates = pgTable('defect_templates', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  orgId: uuid('org_id'),
+  name: text('name').notNull(),
+  beschreibung: text('beschreibung').notNull(),
+  gewerkId: uuid('gewerk_id').references(() => gewerke.id, { onDelete: 'set null' }),
+  defaultBauteil: text('default_bauteil'),
+  defaultFristTage: integer('default_frist_tage'),
+  defaultPriority: integer('default_priority'),
+  fotoHinweis: text('foto_hinweis'),
+  useCount: integer('use_count').default(0).notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+});
+
 /* ----- Activity feed ----- */
 
 export const activity = pgTable('activity', {

--- a/src/routes/(app)/[projectId]/maengel/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/+page.server.ts
@@ -2,18 +2,24 @@ import { fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
-import { gewerke, defectPhotos, defectHistory } from '$lib/db/schema';
+import { gewerke, defectPhotos, defectHistory, defectTemplates } from '$lib/db/schema';
 import { listDefects, listPlans, listContactsForProject, createDefect } from '$lib/db/defectQueries';
-import { asc } from 'drizzle-orm';
+import { asc, desc, eq, sql } from 'drizzle-orm';
 
 export const load: PageServerLoad = async ({ params }) => {
-  const [defects, plans, contacts, gewerkeRows] = await Promise.all([
+  const [defects, plans, contacts, gewerkeRows, templates] = await Promise.all([
     listDefects(params.projectId),
     listPlans(params.projectId),
     listContactsForProject(params.projectId),
-    db ? db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)) : Promise.resolve([])
+    db ? db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)) : Promise.resolve([]),
+    db
+      ? db
+          .select()
+          .from(defectTemplates)
+          .orderBy(desc(defectTemplates.useCount), asc(defectTemplates.name))
+      : Promise.resolve([])
   ]);
-  return { defects, plans, contacts, gewerke: gewerkeRows };
+  return { defects, plans, contacts, gewerke: gewerkeRows, templates };
 };
 
 const photoEntry = z.object({
@@ -79,6 +85,18 @@ export const actions: Actions = {
     }
 
     redirect(303, `/${params.projectId}/maengel/${row.id}`);
+  },
+
+  applyTemplate: async ({ request, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const id = String(fd.id ?? '');
+    if (!id) return fail(400);
+    await db
+      .update(defectTemplates)
+      .set({ useCount: sql`${defectTemplates.useCount} + 1` })
+      .where(eq(defectTemplates.id, id));
+    return { ok: true };
   },
 
   bulkExtract: async ({ request, params, locals }) => {

--- a/src/routes/(app)/[projectId]/maengel/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/+page.svelte
@@ -44,6 +44,36 @@
   let sendBauleiter = $state('');
   let sending = $state(false);
 
+  // Create-Sheet bound state (so templates can prefill)
+  let createSelectedTemplateId = $state<string>('');
+  let createTitle = $state('');
+  let createGewerkId = $state('');
+  let createDeadline = $state('');
+  let createPriority = $state<string>('2');
+  let createDescription = $state('');
+  let createTemplateHinweis = $state<string | null>(null);
+
+  function applyCreateTemplate(id: string) {
+    if (!id) {
+      createSelectedTemplateId = '';
+      createTemplateHinweis = null;
+      return;
+    }
+    const t = parent.templates.find((x) => x.id === id);
+    if (!t) return;
+    createSelectedTemplateId = id;
+    if (!createTitle) createTitle = t.name;
+    if (!createDescription) createDescription = t.beschreibung;
+    if (t.gewerkId && !createGewerkId) createGewerkId = t.gewerkId;
+    if (t.defaultPriority) createPriority = String(t.defaultPriority);
+    if (t.defaultFristTage && !createDeadline) {
+      const d = new Date();
+      d.setDate(d.getDate() + t.defaultFristTage);
+      createDeadline = d.toISOString().slice(0, 10);
+    }
+    createTemplateHinweis = t.fotoHinweis ?? null;
+  }
+
   async function downloadAndSend() {
     if (!sendGewerkId) return;
     sending = true;
@@ -205,27 +235,56 @@
       </div>
       <button class="sheet-close" onclick={() => (showCreate = false)} aria-label="Schließen"><Icon name="close" /></button>
     </div>
-    <form method="POST" action="?/create" use:enhance class="sheet-body">
+    <form method="POST" action="?/create" use:enhance={() => async ({ update }) => {
+      if (createSelectedTemplateId) {
+        const fd = new FormData();
+        fd.append('id', createSelectedTemplateId);
+        await fetch('?/applyTemplate', { method: 'POST', body: fd });
+      }
+      await update();
+    }} class="sheet-body">
       <DraftPhotoStrip projectId={parent.project.id} bind:photos={draftPhotos} />
       <input type="hidden" name="photos" value={draftPhotosJson} />
+      {#if parent.templates.length > 0}
+        <div class="field">
+          <label class="field-label" for="tpl">Mangel-Template</label>
+          <select
+            id="tpl"
+            class="field-input"
+            bind:value={createSelectedTemplateId}
+            onchange={(e) => {
+              const id = (e.currentTarget as HTMLSelectElement).value;
+              applyCreateTemplate(id);
+            }}
+          >
+            <option value="">— frei —</option>
+            {#each parent.templates as t (t.id)}
+              <option value={t.id}>{t.name}{t.useCount > 0 ? ` (${t.useCount}×)` : ''}</option>
+            {/each}
+          </select>
+          {#if createTemplateHinweis}
+            <span class="field-hint">{createTemplateHinweis}</span>
+          {/if}
+        </div>
+      {/if}
       <div class="field">
         <label class="field-label" for="t">Titel</label>
-        <input id="t" name="title" class="field-input" required maxlength="160" autofocus />
+        <input id="t" name="title" class="field-input" bind:value={createTitle} required maxlength="160" />
       </div>
       <div class="field">
         <label class="field-label" for="g">Gewerk</label>
-        <select id="g" name="gewerkId" class="field-input">
+        <select id="g" name="gewerkId" class="field-input" bind:value={createGewerkId}>
           <option value="">— wählen —</option>
           {#each parent.gewerke as g}<option value={g.id}>{g.name}</option>{/each}
         </select>
       </div>
       <div class="field">
         <label class="field-label" for="dl">Deadline</label>
-        <input id="dl" name="deadline" type="date" class="field-input" />
+        <input id="dl" name="deadline" type="date" class="field-input" bind:value={createDeadline} />
       </div>
       <div class="field">
         <label class="field-label" for="pr">Priorität</label>
-        <select id="pr" name="priority" class="field-input">
+        <select id="pr" name="priority" class="field-input" bind:value={createPriority}>
           <option value="2">Normal</option>
           <option value="1">Hoch</option>
           <option value="3">Niedrig</option>
@@ -233,7 +292,7 @@
       </div>
       <div class="field">
         <label class="field-label" for="d">Beschreibung</label>
-        <textarea id="d" name="description" class="field-input" rows="4"></textarea>
+        <textarea id="d" name="description" class="field-input" rows="4" bind:value={createDescription}></textarea>
       </div>
       <button class="btn btn-primary btn-block" type="submit">Anlegen</button>
     </form>

--- a/supabase/migrations/0014_mangel_templates.sql
+++ b/supabase/migrations/0014_mangel_templates.sql
@@ -1,0 +1,123 @@
+-- ============================================================
+-- 0014_mangel_templates
+-- Wiederkehrende Mangel-Templates für 1-Klick-Erfassung
+-- (analog defect_templates aus dem Master-Prompt). 30 globale
+-- Standard-Templates seeden. Idempotent + transactional.
+-- ============================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.defect_templates (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id              uuid,                       -- NULL = global
+  name                text NOT NULL,
+  beschreibung        text NOT NULL,
+  gewerk_id           uuid REFERENCES public.gewerke(id) ON DELETE SET NULL,
+  default_bauteil     text,
+  default_frist_tage  integer,
+  default_priority    integer,                    -- 1=hoch, 2=normal, 3=niedrig
+  foto_hinweis        text,
+  use_count           integer DEFAULT 0 NOT NULL,
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS dt_gewerk_idx ON public.defect_templates(gewerk_id);
+CREATE INDEX IF NOT EXISTS dt_use_count_idx ON public.defect_templates(use_count DESC);
+
+ALTER TABLE public.defect_templates ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "templates read all" ON public.defect_templates;
+CREATE POLICY "templates read all" ON public.defect_templates
+  FOR SELECT TO authenticated USING (true);
+
+DROP POLICY IF EXISTS "templates write authenticated" ON public.defect_templates;
+CREATE POLICY "templates write authenticated" ON public.defect_templates
+  FOR INSERT TO authenticated WITH CHECK (true);
+
+DROP POLICY IF EXISTS "templates update authenticated" ON public.defect_templates;
+CREATE POLICY "templates update authenticated" ON public.defect_templates
+  FOR UPDATE TO authenticated USING (true);
+
+-- ----- Standard-Templates seeden (insert-or-skip via name-Match) -----
+DO $$
+DECLARE
+  g_maler           uuid;
+  g_fliesenleger    uuid;
+  g_elektro         uuid;
+  g_sanitaer        uuid;
+  g_trockenbau      uuid;
+  g_parkett         uuid;
+  g_tueren          uuid;
+  g_fenster         uuid;
+  g_rohbau          uuid;
+  g_aussen          uuid;
+BEGIN
+  SELECT id INTO g_maler         FROM public.gewerke WHERE name = 'Maler' LIMIT 1;
+  SELECT id INTO g_fliesenleger  FROM public.gewerke WHERE name = 'Fliesenleger' LIMIT 1;
+  SELECT id INTO g_elektro       FROM public.gewerke WHERE name = 'Elektro' LIMIT 1;
+  SELECT id INTO g_sanitaer      FROM public.gewerke WHERE name = 'Sanitär/Heizung' LIMIT 1;
+  SELECT id INTO g_trockenbau    FROM public.gewerke WHERE name = 'Trockenbau' LIMIT 1;
+  SELECT id INTO g_parkett       FROM public.gewerke WHERE name = 'Parkett' LIMIT 1;
+  SELECT id INTO g_tueren        FROM public.gewerke WHERE name = 'Türen' LIMIT 1;
+  SELECT id INTO g_fenster       FROM public.gewerke WHERE name = 'Fenster' LIMIT 1;
+  SELECT id INTO g_rohbau        FROM public.gewerke WHERE name = 'Rohbau' LIMIT 1;
+  SELECT id INTO g_aussen        FROM public.gewerke WHERE name = 'Außenanlagen' LIMIT 1;
+
+  INSERT INTO public.defect_templates (name, beschreibung, gewerk_id, default_bauteil, default_frist_tage, default_priority, foto_hinweis)
+  SELECT * FROM (VALUES
+    -- Maler
+    ('Wandfarbe ungleichmäßig', 'Farbauftrag fleckig oder mit sichtbaren Streifen, Nachbesserung erforderlich.', g_maler, 'Wand', 14, 2, 'Bitte aus 1-2m Entfernung im Streiflicht'),
+    ('Lackierung Heizkörper', 'Heizkörper ist unsauber lackiert oder Roststellen sichtbar.', g_maler, 'Heizkörper', 14, 2, NULL),
+    ('Spachtelarbeiten unsauber', 'Übergänge bei Wandanschlüssen sichtbar / nicht plan gespachtelt.', g_maler, 'Wand/Decke', 10, 2, NULL),
+
+    -- Fliesenleger
+    ('Silikonfuge unsauber', 'Silikonfuge an Anschluss Wand/Boden oder Wanne ist nicht sauber gezogen.', g_fliesenleger, 'Fuge', 7, 3, NULL),
+    ('Fliese gerissen', 'Fliese weist Riss/Sprung auf, Austausch erforderlich.', g_fliesenleger, 'Wand/Boden', 14, 2, 'Mit Zollstock oder Münze als Maßstab'),
+    ('Fugenbreite unregelmäßig', 'Fugenbreite zwischen den Fliesen weicht sichtbar ab.', g_fliesenleger, 'Wand', 14, 3, NULL),
+
+    -- Elektro
+    ('Steckdose schief', 'Steckdose oder Schalter ist nicht plan in der Wand / sitzt schief.', g_elektro, 'Wand', 5, 3, NULL),
+    ('Lichtschalter ohne Funktion', 'Lichtschalter schaltet das Licht nicht oder unzuverlässig.', g_elektro, NULL, 3, 1, NULL),
+    ('LAN-Dose fehlt', 'Geplante LAN-Dose wurde nicht installiert.', g_elektro, 'Wand', 7, 2, NULL),
+    ('Steckdose locker', 'Steckdose sitzt nicht fest in der Wand, Rahmen wackelt.', g_elektro, 'Wand', 7, 2, NULL),
+
+    -- Sanitär
+    ('Wasserhahn tropft', 'Armatur ist undicht, Wasser tropft nach Schließen weiter.', g_sanitaer, 'Bad/Küche', 7, 1, NULL),
+    ('Abfluss verstopft', 'Wasser läuft nur langsam ab.', g_sanitaer, NULL, 5, 1, NULL),
+    ('WC-Spülung undicht', 'Wasser läuft nach Spülung weiter in WC-Schüssel.', g_sanitaer, 'WC', 5, 1, NULL),
+    ('Heizkörper wird nicht warm', 'Heizkörper bleibt kalt trotz aufgedrehtem Thermostat.', g_sanitaer, 'Heizkörper', 3, 1, NULL),
+    ('Anschluss Wanne undicht', 'Wasseraustritt am Wanneneinlauf oder Überlauf.', g_sanitaer, 'Bad', 3, 1, 'Bitte vor und nach Wasserversuch'),
+
+    -- Trockenbau
+    ('Riss in der Wand', 'Sichtbarer Riss an Trockenbauwand, Setzungsriss?', g_trockenbau, 'Wand', 14, 2, NULL),
+    ('Stoßfuge nicht verspachtelt', 'Übergang zweier Trockenbauplatten ist nicht verspachtelt.', g_trockenbau, 'Wand', 10, 2, NULL),
+
+    -- Parkett
+    ('Parkett knarrt', 'Parkett knarrt beim Begehen an mehreren Stellen.', g_parkett, 'Boden', 14, 2, NULL),
+    ('Sockelleiste löst sich', 'Sockelleiste hat sich von der Wand gelöst.', g_parkett, 'Sockel', 7, 2, NULL),
+
+    -- Türen
+    ('Tür schleift', 'Tür schleift am Boden oder am Rahmen beim Schließen.', g_tueren, 'Tür', 10, 2, NULL),
+    ('Türschloss klemmt', 'Schloss greift nicht zuverlässig, Schließbart muss gerichtet werden.', g_tueren, 'Tür', 7, 2, NULL),
+    ('Beschlag locker', 'Türgriff oder Schließblech sitzt nicht fest.', g_tueren, 'Tür', 7, 2, NULL),
+
+    -- Fenster
+    ('Fenster zieht', 'Spürbarer Luftzug bei geschlossenem Fenster, Dichtung prüfen.', g_fenster, 'Fenster', 14, 1, NULL),
+    ('Fugenanschluss undicht', 'Anschluss Fenster zu Wand zeigt sichtbare Fuge oder Undichtigkeit.', g_fenster, 'Fenster', 14, 1, 'Bitte aussen + innen fotografieren'),
+    ('Rolladen klemmt', 'Rolladen lässt sich nicht vollständig hoch- oder runterfahren.', g_fenster, 'Fenster', 7, 2, NULL),
+
+    -- Rohbau
+    ('Bodenbelag nicht eben', 'Boden weist Höhenunterschiede > 5mm/m auf.', g_rohbau, 'Boden', 21, 2, 'Mit Wasserwaage messen'),
+    ('Wand nicht im Lot', 'Wand fluchtet nicht / weicht sichtbar von der Senkrechten ab.', g_rohbau, 'Wand', 21, 2, 'Mit Lot messen'),
+
+    -- Außen
+    ('Pflasterung uneben', 'Pflastersteine sitzen nicht plan, Senkungen sichtbar.', g_aussen, 'Belag', 21, 2, NULL),
+    ('Außenanstrich blättert', 'Anstrich an Fassade oder Sockel löst sich.', g_aussen, 'Fassade', 14, 2, NULL),
+    ('Regenrinne hängt durch', 'Regenrinne ist nicht mehr im Gefälle / hängt durch.', g_aussen, 'Dach', 21, 2, NULL)
+  ) AS v(name, beschreibung, gewerk_id, default_bauteil, default_frist_tage, default_priority, foto_hinweis)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM public.defect_templates t WHERE t.name = v.name AND t.org_id IS NULL
+  );
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## ⚠️ MIGRATION

```
supabase/migrations/0014_mangel_templates.sql
```

**Migration 0014 benötigt — Laurenz muss SQL manuell in Supabase laufen lassen vor Merge.**

Idempotent (Name-basierter `NOT EXISTS`-Guard pro Template). Seedet
**30 Standard-Vorlagen** beim ersten Run.

Self-Merge **nicht zulässig**.

## Was es macht

Im "Mangel anlegen"-Sheet erscheint oben eine Combobox **„Mangel-
Template"**. Auswahl füllt vor:

| Feld | Quelle |
|---|---|
| Titel | template.name |
| Beschreibung | template.beschreibung |
| Gewerk | template.gewerk_id (falls leer) |
| Priorität | template.default_priority |
| Deadline | heute + template.default_frist_tage |

Plus optional ein Hint unter der Combobox (z.B. „Bitte mit Zollstock
oder Münze als Maßstab fotografieren").

`useCount` wird beim Submit serverseitig hochgezählt → häufig
verwendete Templates erscheinen oben in der Sortierung
(`ORDER BY use_count DESC, name ASC`).

## Seed-Inhalt

30 Templates über die 10 Haupt-Gewerke verteilt:

| Gewerk | # Templates | Beispiele |
|---|---|---|
| Maler | 3 | Wandfarbe ungleichmäßig, Lackierung Heizkörper, Spachtelarbeiten unsauber |
| Fliesenleger | 3 | Silikonfuge unsauber, Fliese gerissen, Fugenbreite unregelmäßig |
| Elektro | 4 | Steckdose schief, Lichtschalter ohne Funktion, LAN-Dose fehlt, Steckdose locker |
| Sanitär/Heizung | 5 | Wasserhahn tropft, Abfluss verstopft, WC-Spülung undicht, Heizkörper kalt, Wanne undicht |
| Trockenbau | 2 | Riss in Wand, Stoßfuge nicht verspachtelt |
| Parkett | 2 | Parkett knarrt, Sockelleiste lose |
| Türen | 3 | Tür schleift, Türschloss klemmt, Beschlag locker |
| Fenster | 3 | Fenster zieht, Fugenanschluss undicht, Rolladen klemmt |
| Rohbau | 2 | Bodenbelag nicht eben, Wand nicht im Lot |
| Außen | 3 | Pflasterung uneben, Außenanstrich blättert, Regenrinne hängt durch |

Migration nutzt `SELECT id FROM gewerke WHERE name = 'X'` für jedes
Gewerk — wenn ein Gewerk fehlt (sollte nicht passieren da Migration 0000
diese seedet), wird `gewerk_id` NULL gesetzt, kein Crash.

## Diff (5 Files, ~240 LoC)

| File | Was |
|---|---|
| `supabase/migrations/0014_mangel_templates.sql` | NEU + Seed |
| `src/lib/db/schema.ts` | + defectTemplates table |
| `src/routes/(app)/[projectId]/maengel/+page.{svelte,server.ts}` | + Combobox, applyTemplate-Action, prefill state |
| `docs/CHANGELOG.md` | Doku |

## Self-Review

- [x] RLS: read-all für authenticated, write/update auch (Templates
      sind kollaborativ, keine projekt-spezifische RLS nötig)
- [x] Edge-Case: Template ohne gewerk_id → kein Prefill, sonst alles
- [x] Edge-Case: bereits ausgefülltes Title-Feld → Template überschreibt
      es **nicht** (`if (!createTitle)`-Guard)
- [x] Race: useCount-Increment via SQL-Expression `+1` (atomic)
- [x] type-check 0 errors · Tests 17/17 grün · Build clean

## Test plan

- [ ] Migration 0014 in Supabase ausführen
- [ ] Mängel-Tab → Plus-Button → Sheet zeigt Template-Combobox mit 30 Einträgen
- [ ] „Silikonfuge unsauber" wählen → Title/Beschreibung/Gewerk/Frist gefüllt
- [ ] Submit → Mangel angelegt, useCount steigt
- [ ] Sheet erneut öffnen → „Silikonfuge unsauber (1×)" oben in Liste

## Out-of-scope (Phase 5+)

- Templates-Editor-UI (heute nur per SQL)
- Foto-Hinweis als Pflichtfeld (heute nur Hint-Text)
- Project-spezifische Templates (heute global only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbUj3rMskT3mNqBk2DSPkG)_