### PR TITLE
feat: Termin-Maengel-Verknuepfung Phase 1

### DIFF
--- a/.autopilot/PROPOSALS.md
+++ b/.autopilot/PROPOSALS.md
@@ -15,7 +15,64 @@ Pro Vorschlag wird zusätzlich ein GitHub-Issue erstellt mit Reaktion-Buttons.
 
 ## Aktive Vorschlaege
 
-(Liste startet leer.)
+### H-001: Termin-Mängel-Verknüpfung Phase 1
+
+**Hypothese**: Bauleiter Marc fährt zur Abnahme Trockenbau Haus 1. Er will
+wissen: "Welche Mängel gehören zu DIESEM Termin?" Heute: Bauzeitenplan öffnen
+→ Termin sehen → zu Mängel-Tab wechseln → Gewerk Trockenbau filtern → auf
+Datum scrollen → vergleichen. Das sind 6-8 Klicks und ca. 2-3 Minuten pro
+Termin-Check. Bei 5 Terminen/Tag = 10-15 Min/Tag verschwendet.
+Umgekehrt: Ein Mangel zeigt nicht welcher Termin davon blockiert wird.
+Bauleiter muss manuell im Kopf zuordnen — fehleranfällig.
+
+**Lösung**: `defects.task_id` als FK auf `tasks.id`. Jeder Mangel kann einem
+Termin zugeordnet werden (über gemeinsames Gewerk automatisch vorgeschlagen).
+Task-Detail zeigt verlinkte Mängel-Liste. Mangel-Detail zeigt zugehörigen
+Termin mit Plan-Ende-Datum.
+
+**Erfolgsmessung**: "Welche Mängel hat dieser Termin?" von 6-8 Klicks auf
+1 Klick (Termin öffnen → Liste da). Mangel-Detail zeigt Termin-Kontext
+ohne Recherche. Eliminiert Doppel-Recherche bei Mängel-Bearbeitung.
+
+**Status**: In Arbeit
+
+---
+
+### H-002: Verzug-Ampel im Bauzeitenplan
+
+**Hypothese**: Bauleiter sieht im Gantt-Chart nur Balken ohne Kontext zu
+Mängeln. Er muss sich merken oder manuell nachschlagen welche Termine durch
+offene Mängel blockiert sind. Bei 150 Terminen pro Projekt ist das unmöglich
+— Verzug wird erst erkannt wenn es zu spät ist.
+
+**Lösung**: Gantt-Bar wird rot wenn Termin überfällig UND offene Mängel hat.
+Grün wenn alle Mängel erledigt. Tooltip zeigt "N offene Mängel blockieren
+Folgegewerk Y".
+
+**Erfolgsmessung**: Verzug-Erkennung von "manuelles Nachschlagen pro Termin"
+(~5 Min) auf sofortige visuelle Erkennung (0 Klicks). Bauleiter sieht auf
+einen Blick welche Termine Probleme haben.
+
+**Status**: Pending (nach Item 1)
+
+---
+
+### H-003: KPI "Wegen Mängeln verlorene Tage pro Gewerk"
+
+**Hypothese**: Bauleiter und Projektleiter haben keine Übersicht welche
+Gewerke den Bauzeitenplan am meisten verzögern. Entscheidungen über
+Nachunternehmer-Wechsel oder Vertragsstrafen basieren auf Bauchgefühl statt
+Daten.
+
+**Lösung**: Neuer Bar-Chart im Statistik-Dashboard: Differenz zwischen
+Plan-Ende des Termins und tatsächlichem Erledigt-Datum aller zugeordneten
+Mängel, aggregiert pro Gewerk.
+
+**Erfolgsmessung**: Datenbasierte Aussage "Gewerk X hat Y Tage Verzug
+verursacht" ohne manuelles Zusammenrechnen. Grundlage für Nachunternehmer-
+Gespräche und VOB-Maßnahmen.
+
+**Status**: Pending (nach Item 2)
 
 ## Archiv
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,14 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 
 ## [unreleased] — post-rc2
 
+### Added
+- feat(verknuepfung): Termin-Mängel-Verknüpfung Phase 1 — jeder Mangel
+  kann einem Bauzeitenplan-Termin zugeordnet werden (defects.task_id FK).
+  Task-Detail zeigt verknüpfte Mängel-Liste (1 Klick statt 6-8).
+  Mangel-Detail zeigt zugehörigen Termin mit Plan-Ende-Datum und
+  Direktlink. Gewerk-basierte Termin-Vorschläge im Dropdown.
+  Migration 0015 (additive, task_id + Index). (PR #TBD)
+
 ### Fixed
 - 🔥 **HOTFIX** fix(maengel/perf): Mängel-Seite lief in
   Production in 300s-Timeout. Zwei Bottlenecks behoben — keine

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,6 +1,11 @@
 # PROGRESS
 
-**post-rc2 Session** (heute):
+**Nacht-Session 2026-05-02** (Autopilot):
+- PR #TBD: Termin-Mängel-Verknüpfung Phase 1 — defects.task_id FK,
+  bidirektionale UI (Task zeigt Mängel, Mangel zeigt Termin),
+  Migration 0015, 6 Unit-Tests
+
+**post-rc2 Session** (davor):
 - PR #5 (gemerged): /checklisten FROM-clause-Fix
 - PR #6 (gemerged): /checklisten/[id] empty-progress IN()-Fix
 - PR #7 (offen, **Migration 0007**): Plan-Crop für Mängel — 400×300 JPEG

--- a/src/lib/db/defectQueries.ts
+++ b/src/lib/db/defectQueries.ts
@@ -8,6 +8,7 @@ import {
   gewerke,
   apartments,
   houses,
+  tasks,
   activity
 } from './schema';
 import { eq, and, asc, desc, sql, inArray } from 'drizzle-orm';
@@ -35,6 +36,7 @@ export async function listDefects(projectId: string) {
       roomId: defects.roomId,
       bauteil: defects.bauteil,
       bauteilqualitaet: defects.bauteilqualitaet,
+      taskId: defects.taskId,
       createdAt: defects.createdAt
     })
     .from(defects)
@@ -56,11 +58,12 @@ export async function getDefect(projectId: string, defectId: string) {
   const [c] = d.contactId ? await db.select().from(contacts).where(eq(contacts.id, d.contactId)).limit(1) : [null];
   const [p] = d.planId ? await db.select().from(plans).where(eq(plans.id, d.planId)).limit(1) : [null];
   const [a] = d.apartmentId ? await db.select().from(apartments).where(eq(apartments.id, d.apartmentId)).limit(1) : [null];
+  const [t] = d.taskId ? await db.select().from(tasks).where(eq(tasks.id, d.taskId)).limit(1) : [null];
 
   const photos = await db.select().from(defectPhotos).where(eq(defectPhotos.defectId, d.id));
   const history = await db.select().from(defectHistory).where(eq(defectHistory.defectId, d.id)).orderBy(desc(defectHistory.createdAt));
 
-  return { defect: d, gewerk: g, contact: c, plan: p, apartment: a, photos, history };
+  return { defect: d, gewerk: g, contact: c, plan: p, apartment: a, task: t, photos, history };
 }
 
 /**
@@ -93,6 +96,7 @@ export type CreateDefectInput = {
   xPct?: number | null;
   yPct?: number | null;
   planCropPath?: string | null;
+  taskId?: string | null;
   deadline?: string | null;
   priority?: number;
   createdBy: string;
@@ -116,6 +120,7 @@ export async function createDefect(input: CreateDefectInput) {
       xPct: input.xPct != null ? input.xPct.toString() : null,
       yPct: input.yPct != null ? input.yPct.toString() : null,
       planCropPath: input.planCropPath ?? null,
+      taskId: input.taskId ?? null,
       deadline: input.deadline ?? null,
       priority: input.priority ?? 2,
       status: 'open',
@@ -150,6 +155,7 @@ export async function updateDefectFields(
     gewerkId: string | null;
     contactId: string | null;
     apartmentId: string | null;
+    taskId: string | null;
     deadline: string | null;
     followupDate: string | null;
     dueDate: string | null;
@@ -257,4 +263,24 @@ export async function listContactsForProject(projectId: string) {
     .leftJoin(gewerke, eq(gewerke.id, contacts.gewerkId))
     .where(sql`(${contacts.projectId} = ${projectId} OR ${contacts.projectId} IS NULL)`)
     .orderBy(asc(gewerke.name));
+}
+
+/** All defects linked to a specific task (for task-detail view). */
+export async function listDefectsForTask(taskId: string) {
+  if (!db) return [];
+  return await db
+    .select({
+      id: defects.id,
+      shortId: defects.shortId,
+      title: defects.title,
+      status: defects.status,
+      priority: defects.priority,
+      deadline: defects.deadline,
+      gewerkName: gewerke.name,
+      gewerkColor: gewerke.color
+    })
+    .from(defects)
+    .leftJoin(gewerke, eq(gewerke.id, defects.gewerkId))
+    .where(eq(defects.taskId, taskId))
+    .orderBy(asc(defects.shortId));
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -263,6 +263,7 @@ export const defects = pgTable('defects', {
   apartmentId: uuid('apartment_id').references(() => apartments.id),
   gewerkId: uuid('gewerk_id').references(() => gewerke.id),
   contactId: uuid('contact_id').references(() => contacts.id),
+  taskId: uuid('task_id').references(() => tasks.id, { onDelete: 'set null' }),
   title: text('title').notNull(),
   description: text('description'),
   deadline: date('deadline'),

--- a/src/routes/(app)/[projectId]/bauzeitenplan/+page.server.ts
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/+page.server.ts
@@ -2,19 +2,27 @@ import { redirect, fail } from '@sveltejs/kit';
 import { z } from 'zod';
 import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
-import { tasks, taskBaselines, taskDependencies, gewerke, houses, apartments, activity } from '$lib/db/schema';
-import { eq, and, asc, desc, or } from 'drizzle-orm';
+import { tasks, taskBaselines, taskDependencies, gewerke, houses, apartments, activity, defects } from '$lib/db/schema';
+import { eq, and, asc, desc, or, sql } from 'drizzle-orm';
 import { loadGaisbachSample } from '$lib/db/projectQueries';
 import { getProjectTasksAndDeps, applyTaskUpdates } from '$lib/db/taskQueries';
 import { propagate, type EngineTask, type EngineDep } from '$lib/gantt/engine';
 
 export const load: PageServerLoad = async ({ params }) => {
   const { tasks: tRows, deps } = await getProjectTasksAndDeps(params.projectId);
-  if (!db) return { tasks: tRows, deps, gewerke: [], houses: [], baselineLabels: [] };
+  if (!db) return { tasks: tRows, deps, gewerke: [], houses: [], baselineLabels: [], taskDefectCounts: [] };
 
-  const [gewerkeRows, houseRows] = await Promise.all([
+  const [gewerkeRows, houseRows, taskDefectCounts] = await Promise.all([
     db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)),
-    db.select().from(houses).where(eq(houses.projectId, params.projectId)).orderBy(asc(houses.sortOrder))
+    db.select().from(houses).where(eq(houses.projectId, params.projectId)).orderBy(asc(houses.sortOrder)),
+    db.select({
+      taskId: defects.taskId,
+      total: sql<number>`count(*)::int`,
+      open: sql<number>`count(*) FILTER (WHERE ${defects.status} NOT IN ('resolved', 'accepted', 'rejected'))::int`
+    })
+      .from(defects)
+      .where(and(eq(defects.projectId, params.projectId), sql`${defects.taskId} IS NOT NULL`))
+      .groupBy(defects.taskId)
   ]);
 
   // Aggregate apartments per house
@@ -39,7 +47,7 @@ export const load: PageServerLoad = async ({ params }) => {
     baselineLabels.push({ label: r.label, snapshotAt: r.snapshotAt });
   }
 
-  return { tasks: tRows, deps, gewerke: gewerkeRows, houses: houseTree, baselineLabels };
+  return { tasks: tRows, deps, gewerke: gewerkeRows, houses: houseTree, baselineLabels, taskDefectCounts };
 };
 
 const moveSchema = z.object({

--- a/src/routes/(app)/[projectId]/bauzeitenplan/[taskId]/+page.server.ts
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/[taskId]/+page.server.ts
@@ -5,17 +5,21 @@ import { db } from '$lib/db/client';
 import { tasks, activity, taskPhotos } from '$lib/db/schema';
 import { eq, and, asc } from 'drizzle-orm';
 import { getTaskWithApartmentProgress, setApartmentProgress } from '$lib/db/taskQueries';
+import { listDefectsForTask } from '$lib/db/defectQueries';
 
 export const load: PageServerLoad = async ({ params }) => {
   const detail = await getTaskWithApartmentProgress(params.projectId, params.taskId);
   if (!detail) error(404, 'Termin nicht gefunden');
-  if (!db) return { ...detail, photos: [] };
-  const photos = await db
-    .select()
-    .from(taskPhotos)
-    .where(eq(taskPhotos.taskId, params.taskId))
-    .orderBy(asc(taskPhotos.sortOrder), asc(taskPhotos.createdAt));
-  return { ...detail, photos };
+  if (!db) return { ...detail, photos: [], linkedDefects: [] };
+  const [photos, linkedDefects] = await Promise.all([
+    db
+      .select()
+      .from(taskPhotos)
+      .where(eq(taskPhotos.taskId, params.taskId))
+      .orderBy(asc(taskPhotos.sortOrder), asc(taskPhotos.createdAt)),
+    listDefectsForTask(params.taskId)
+  ]);
+  return { ...detail, photos, linkedDefects };
 };
 
 const aptProgressSchema = z.object({

--- a/src/routes/(app)/[projectId]/bauzeitenplan/[taskId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/[taskId]/+page.svelte
@@ -204,6 +204,24 @@
     </div>
   {/if}
 
+  <div class="field">
+    <span class="field-label">Verknüpfte Mängel <span class="count">{parent.linkedDefects?.length ?? 0}</span></span>
+    {#if (parent.linkedDefects?.length ?? 0) > 0}
+      <div class="defect-link-list">
+        {#each parent.linkedDefects as d (d.id)}
+          <a class="defect-link-card" href={`/${parent.project.id}/maengel/${d.id}`}>
+            <span class="defect-link-dot" style={`background:${d.gewerkColor ?? '#9CA3AF'}`}></span>
+            <span class="defect-link-id">{d.shortId}</span>
+            <span class="defect-link-title">{d.title}</span>
+            <span class="defect-link-status status-{d.status}">{d.status}</span>
+          </a>
+        {/each}
+      </div>
+    {:else}
+      <p class="field-hint">Keine Mängel mit diesem Termin verknüpft. Mängel können im Mangel-Detail einem Termin zugeordnet werden.</p>
+    {/if}
+  </div>
+
   {#if isPerApartment && parent.apartments.length > 0}
     <h3 class="section-title">Pro Wohnung <span class="count">{parent.apartments.length}</span></h3>
     <div class="apt-grid">
@@ -276,4 +294,15 @@
   .progress-slider { width: 100%; height: 6px; appearance: none; background: linear-gradient(to right, var(--c, var(--blue)) 0 var(--p), var(--grey-soft) var(--p) 100%); border-radius: 999px; outline: none; cursor: pointer; }
   .progress-slider::-webkit-slider-thumb { appearance: none; width: 18px; height: 18px; border-radius: 50%; background: var(--paper); border: 2px solid var(--c, var(--blue)); cursor: grab; box-shadow: var(--shadow-1); }
   .progress-slider::-moz-range-thumb { width: 18px; height: 18px; border-radius: 50%; background: var(--paper); border: 2px solid var(--c, var(--blue)); cursor: grab; }
+  .defect-link-list { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
+  .defect-link-card { display: flex; align-items: center; gap: 8px; padding: 8px 10px; background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); text-decoration: none; color: inherit; transition: all .12s; min-height: 44px; }
+  .defect-link-card:hover { border-color: var(--line-strong); box-shadow: var(--shadow-1); }
+  .defect-link-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
+  .defect-link-id { font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--muted); flex-shrink: 0; }
+  .defect-link-title { flex: 1; min-width: 0; font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .defect-link-status { font-family: var(--mono); font-size: 9px; font-weight: 700; text-transform: uppercase; padding: 2px 8px; border-radius: 999px; flex-shrink: 0; }
+  .defect-link-status.status-open, .defect-link-status.status-reopened { background: var(--red-soft); color: var(--red); }
+  .defect-link-status.status-sent, .defect-link-status.status-acknowledged { background: var(--amber-soft); color: var(--amber); }
+  .defect-link-status.status-resolved, .defect-link-status.status-accepted { background: var(--green-soft); color: var(--green); }
+  .defect-link-status.status-rejected { background: var(--grey-soft); color: var(--muted); }
 </style>

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.server.ts
@@ -2,7 +2,7 @@ import { error, fail } from '@sveltejs/kit';
 import { z } from 'zod';
 import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
-import { defectPhotos, defectHistory, gewerke, contacts, textbausteine } from '$lib/db/schema';
+import { defectPhotos, defectHistory, gewerke, contacts, textbausteine, tasks } from '$lib/db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { getDefect, updateDefectFields, listContactsForProject } from '$lib/db/defectQueries';
 import { listVorgaenge, addVorgang, listBriefVorlagen, getFirmaSettings } from '$lib/db/vorgangQueries';
@@ -10,15 +10,19 @@ import { listVorgaenge, addVorgang, listBriefVorlagen, getFirmaSettings } from '
 export const load: PageServerLoad = async ({ params }) => {
   const detail = await getDefect(params.projectId, params.defectId);
   if (!detail) error(404, 'Mangel nicht gefunden');
-  if (!db) return { ...detail, gewerke: [], contacts: [], textbausteine: [], vorgaenge: [], briefVorlagen: [], firma: null };
+  if (!db) return { ...detail, gewerke: [], contacts: [], textbausteine: [], vorgaenge: [], briefVorlagen: [], firma: null, projectTasks: [] };
 
-  const [gewerkeRows, contactsRows, textRows, vorgaenge, briefVorlagen, firma] = await Promise.all([
+  const [gewerkeRows, contactsRows, textRows, vorgaenge, briefVorlagen, firma, projectTasks] = await Promise.all([
     db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)),
     listContactsForProject(params.projectId),
     db.select().from(textbausteine).orderBy(asc(textbausteine.sortOrder)),
     listVorgaenge(params.defectId),
     listBriefVorlagen(params.projectId),
-    getFirmaSettings()
+    getFirmaSettings(),
+    db.select({ id: tasks.id, name: tasks.name, num: tasks.num, gewerkId: tasks.gewerkId, endDate: tasks.endDate })
+      .from(tasks)
+      .where(eq(tasks.projectId, params.projectId))
+      .orderBy(asc(tasks.sortOrder))
   ]);
 
   return {
@@ -28,7 +32,8 @@ export const load: PageServerLoad = async ({ params }) => {
     textbausteine: textRows,
     vorgaenge,
     briefVorlagen,
-    firma
+    firma,
+    projectTasks
   };
 };
 
@@ -38,6 +43,7 @@ const fieldsSchema = z.object({
   gewerkId: z.string().uuid().optional().or(z.literal('')),
   contactId: z.string().uuid().optional().or(z.literal('')),
   apartmentId: z.string().uuid().optional().or(z.literal('')),
+  taskId: z.string().uuid().optional().or(z.literal('')),
   deadline: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().or(z.literal('')),
   followupDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().or(z.literal('')),
   dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().or(z.literal('')),
@@ -80,7 +86,7 @@ export const actions: Actions = {
     const fields: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(parsed.data)) {
       if (v === '' || v === undefined) {
-        if (['gewerkId', 'contactId', 'apartmentId', 'deadline', 'followupDate'].includes(k)) {
+        if (['gewerkId', 'contactId', 'apartmentId', 'taskId', 'deadline', 'followupDate'].includes(k)) {
           fields[k] = null;
         }
       } else {

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
@@ -147,6 +147,17 @@
   let description = $state(data.defect.description ?? '');
   let gewerkId = $state(data.defect.gewerkId ?? '');
   let contactId = $state(data.defect.contactId ?? '');
+  let taskId = $state(data.defect.taskId ?? '');
+
+  // Filter tasks by same gewerk (if set), but always show all
+  let filteredTasks = $derived.by(() => {
+    const all = parent.projectTasks ?? [];
+    if (!gewerkId) return all;
+    // Show matching gewerk tasks first, then the rest
+    const matching = all.filter((t) => t.gewerkId === gewerkId);
+    const rest = all.filter((t) => t.gewerkId !== gewerkId);
+    return [...matching, ...rest];
+  });
   let deadline = $state(data.defect.deadline ?? '');
   let followupDate = $state(data.defect.followupDate ?? '');
   let priority = $state(String(data.defect.priority ?? 2));
@@ -198,7 +209,7 @@
   }
 
   async function save() {
-    const res = await postForm('saveFields', { title, description, gewerkId, contactId, deadline, followupDate, priority, status });
+    const res = await postForm('saveFields', { title, description, gewerkId, contactId, taskId, deadline, followupDate, priority, status });
     if (res.ok) toast('Gespeichert.');
     else toast('Fehler.');
   }
@@ -403,6 +414,26 @@
         <option value={c.id}>{c.company} ({c.email ?? '—'})</option>
       {/each}
     </select>
+  </div>
+
+  <div class="field">
+    <label class="field-label" for="tid">Verknüpfter Termin</label>
+    <select id="tid" class="field-input" bind:value={taskId} onchange={save}>
+      <option value="">— kein Termin —</option>
+      {#each filteredTasks as t (t.id)}
+        <option value={t.id}>{t.num ? `${t.num} ` : ''}{t.name} (Ende: {t.endDate})</option>
+      {/each}
+    </select>
+    {#if taskId && parent.task}
+      <a class="task-link-card" href={`/${parent.project.id}/bauzeitenplan/${taskId}`}>
+        <span class="task-link-icon">📅</span>
+        <span class="task-link-text">
+          <span class="task-link-name">{parent.task.num ? `${parent.task.num} ` : ''}{parent.task.name}</span>
+          <span class="task-link-date">Plan-Ende: {parent.task.endDate}</span>
+        </span>
+        <span class="task-link-arrow">→</span>
+      </a>
+    {/if}
   </div>
 
   <h3 class="section-title">Fotos <span class="count">{parent.photos.length}</span></h3>
@@ -626,4 +657,11 @@
   .status-sent, .status-acknowledged { background: var(--amber-soft); color: var(--amber); }
   .status-resolved, .status-accepted { background: var(--green-soft); color: var(--green); }
   .status-rejected { background: var(--grey-soft); color: var(--muted); }
+  .task-link-card { display: flex; align-items: center; gap: 10px; padding: 10px 12px; margin-top: 8px; background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); text-decoration: none; color: inherit; transition: all .12s; min-height: 44px; }
+  .task-link-card:hover { border-color: var(--line-strong); box-shadow: var(--shadow-1); }
+  .task-link-icon { font-size: 18px; flex-shrink: 0; }
+  .task-link-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+  .task-link-name { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .task-link-date { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+  .task-link-arrow { font-size: 14px; color: var(--muted); flex-shrink: 0; }
 </style>

--- a/supabase/migrations/0015_defect_task_link.sql
+++ b/supabase/migrations/0015_defect_task_link.sql
@@ -1,0 +1,27 @@
+-- ============================================================
+-- 0015_defect_task_link
+-- Adds task_id FK to defects table — links Mängel to
+-- Bauzeitenplan-Termine. Additive, idempotent, transactional.
+-- ============================================================
+
+BEGIN;
+
+-- Add column if it doesn't exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'defects'
+      AND column_name = 'task_id'
+  ) THEN
+    ALTER TABLE public.defects
+      ADD COLUMN task_id uuid REFERENCES public.tasks(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Index for fast lookups: "all defects for a given task"
+CREATE INDEX IF NOT EXISTS defects_task_id_idx ON public.defects(task_id)
+  WHERE task_id IS NOT NULL;
+
+COMMIT;

--- a/tests/unit/task-defect-link.test.ts
+++ b/tests/unit/task-defect-link.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Unit-tests for Task-Defect linking logic.
+ * Tests the schema-level relationship and filtering logic
+ * that will be used in the UI (filteredTasks, defect counts).
+ */
+
+type TaskStub = { id: string; name: string; gewerkId: string | null; endDate: string };
+type DefectStub = { id: string; shortId: string; taskId: string | null; status: string; gewerkId: string | null };
+
+// Mirrors the filteredTasks logic from defect detail page
+function filterTasksByGewerk(allTasks: TaskStub[], gewerkId: string | null): TaskStub[] {
+  if (!gewerkId) return allTasks;
+  const matching = allTasks.filter((t) => t.gewerkId === gewerkId);
+  const rest = allTasks.filter((t) => t.gewerkId !== gewerkId);
+  return [...matching, ...rest];
+}
+
+// Mirrors the defect counting logic from bauzeitenplan server
+function taskDefectCounts(defects: DefectStub[]): Map<string, { total: number; open: number }> {
+  const map = new Map<string, { total: number; open: number }>();
+  const closedStatuses = ['resolved', 'accepted', 'rejected'];
+  for (const d of defects) {
+    if (!d.taskId) continue;
+    const entry = map.get(d.taskId) ?? { total: 0, open: 0 };
+    entry.total++;
+    if (!closedStatuses.includes(d.status)) entry.open++;
+    map.set(d.taskId, entry);
+  }
+  return map;
+}
+
+describe('filterTasksByGewerk', () => {
+  const tasks: TaskStub[] = [
+    { id: 't1', name: 'Elektro Haus 1', gewerkId: 'g-elektro', endDate: '2026-05-10' },
+    { id: 't2', name: 'Maler Haus 1', gewerkId: 'g-maler', endDate: '2026-05-15' },
+    { id: 't3', name: 'Elektro Haus 2', gewerkId: 'g-elektro', endDate: '2026-05-20' },
+    { id: 't4', name: 'Allgemein', gewerkId: null, endDate: '2026-05-25' }
+  ];
+
+  it('returns all tasks when no gewerk filter', () => {
+    const result = filterTasksByGewerk(tasks, null);
+    expect(result).toHaveLength(4);
+    expect(result[0].id).toBe('t1');
+  });
+
+  it('sorts matching gewerk first', () => {
+    const result = filterTasksByGewerk(tasks, 'g-elektro');
+    expect(result[0].id).toBe('t1');
+    expect(result[1].id).toBe('t3');
+    expect(result[2].id).toBe('t2');
+    expect(result[3].id).toBe('t4');
+  });
+
+  it('returns all tasks even with gewerk filter (non-matching at end)', () => {
+    const result = filterTasksByGewerk(tasks, 'g-maler');
+    expect(result).toHaveLength(4);
+    expect(result[0].id).toBe('t2'); // matching first
+  });
+});
+
+describe('taskDefectCounts', () => {
+  const defects: DefectStub[] = [
+    { id: 'd1', shortId: 'M-001', taskId: 't1', status: 'open', gewerkId: 'g1' },
+    { id: 'd2', shortId: 'M-002', taskId: 't1', status: 'resolved', gewerkId: 'g1' },
+    { id: 'd3', shortId: 'M-003', taskId: 't1', status: 'sent', gewerkId: 'g1' },
+    { id: 'd4', shortId: 'M-004', taskId: 't2', status: 'accepted', gewerkId: 'g2' },
+    { id: 'd5', shortId: 'M-005', taskId: null, status: 'open', gewerkId: 'g1' }
+  ];
+
+  it('counts total and open defects per task', () => {
+    const counts = taskDefectCounts(defects);
+    expect(counts.get('t1')?.total).toBe(3);
+    expect(counts.get('t1')?.open).toBe(2); // open + sent
+    expect(counts.get('t2')?.total).toBe(1);
+    expect(counts.get('t2')?.open).toBe(0); // accepted = closed
+  });
+
+  it('ignores defects without taskId', () => {
+    const counts = taskDefectCounts(defects);
+    expect(counts.has('null')).toBe(false);
+    expect(counts.size).toBe(2);
+  });
+
+  it('returns empty map for no defects', () => {
+    const counts = taskDefectCounts([]);
+    expect(counts.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Migration 0015**: `defects.task_id` FK auf `tasks.id` (additive, idempotent) + Index
- **Task-Detail** zeigt verknuepfte Maengel als klickbare Liste mit Status-Pill
- **Mangel-Detail** zeigt verknuepften Termin (Plan-Ende, Direktlink) + Dropdown zum Zuordnen
- **Bauzeitenplan-Server** liefert Defect-Counts pro Task (total/open) — Vorbereitung fuer Verzug-Ampel (Item 2)
- 6 Unit-Tests fuer Filterlogik und Counting

## Hypothese

Bauleiter Marc will wissen: "Welche Maengel gehoeren zu DIESEM Termin?" Heute: 6-8 Klicks (Tab-Wechsel, Filter, Scrollen). Mit Verknuepfung: 1 Klick auf Termin → Liste da. Umgekehrt: Mangel zeigt "Gehoert zu Termin X (Plan-Ende: Datum)" — eliminiert Doppel-Recherche.

**Erfolgsmessung**: 6-8 Klicks → 1 Klick. Plus bidirektionale Sichtbarkeit.

## Test plan

- [ ] Migration 0015 via `supabase db push` deployen
- [ ] Mangel oeffnen → Termin-Dropdown pruefen (Gewerk-basiert vorsortiert)
- [ ] Termin zuordnen → Speichern → Task-Detail oeffnen → Mangel in Liste sichtbar
- [ ] Mangel ohne Termin: Empty-State pruefen
- [ ] Mobile-Test (375px): Touch-Targets, kein Overflow
- [ ] `pnpm check` + `vitest run` gruen

🤖 Generated with [Claude Code](https://claude.com/claude-code)