### PR TITLE
feat: Verzug-Ampel im Bauzeitenplan

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,11 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
   Task-Detail zeigt verknüpfte Mängel-Liste (1 Klick statt 6-8).
   Mangel-Detail zeigt zugehörigen Termin mit Plan-Ende-Datum und
   Direktlink. Gewerk-basierte Termin-Vorschläge im Dropdown.
-  Migration 0015 (additive, task_id + Index). (PR #TBD)
+  Migration 0015 (additive, task_id + Index). (PR #25)
+- feat(verzug-ampel): Gantt-Bars werden rot wenn Termin ueberfaellig
+  UND offene Maengel hat, gruen wenn alle erledigt. Tooltip zeigt
+  "N offene Maengel / M gesamt" mit Verzug-Warnung. Sofortige
+  visuelle Erkennung statt manuelles Nachschlagen. (PR #TBD)
 
 ### Fixed
 - 🔥 **HOTFIX** fix(maengel/perf): Mängel-Seite lief in

--- a/src/lib/components/Gantt.svelte
+++ b/src/lib/components/Gantt.svelte
@@ -14,6 +14,8 @@
     progressPct?: number;
   };
 
+  type TaskDefectCount = { taskId: string | null; total: number; open: number };
+
   type Baseline = { taskId: string; plannedStart: string; plannedEnd: string };
   export type Dependency = {
     id: string;
@@ -33,6 +35,7 @@
     baseline?: Baseline[];
     dependencies?: Dependency[];
     lookaheadWeeks?: 0 | 3 | 4 | 6;
+    taskDefectCounts?: TaskDefectCount[];
   };
   let {
     tasks,
@@ -43,8 +46,27 @@
     criticalPathIds = new Set<string>(),
     baseline = [],
     dependencies = [],
-    lookaheadWeeks = 0
+    lookaheadWeeks = 0,
+    taskDefectCounts = []
   }: Props = $props();
+
+  /* ===== Verzug-Ampel: task overdue + open defects = red, all resolved = green ===== */
+  let defectMap = $derived.by(() => {
+    const m = new Map<string, { total: number; open: number }>();
+    for (const c of taskDefectCounts) {
+      if (c.taskId) m.set(c.taskId, { total: c.total, open: c.open });
+    }
+    return m;
+  });
+
+  function verzugStatus(t: GTask): 'overdue' | 'clear' | 'none' {
+    const counts = defectMap.get(t.id);
+    if (!counts || counts.total === 0) return 'none';
+    const today = fmtDate(new Date());
+    if (t.endDate < today && counts.open > 0) return 'overdue';
+    if (counts.open === 0) return 'clear';
+    return 'none';
+  }
 
   let baselineMap = $derived.by(() => {
     const m = new Map<string, { plannedStart: string; plannedEnd: string }>();
@@ -434,6 +456,7 @@
             {#if isParentMap.has(t.id)}
               <div class="gantt-bar summary" style={`left:${offsetPx(t.startDate)}px;width:${widthFor(t)}px`}></div>
             {:else}
+              {@const vs = verzugStatus(t)}
               <button
                 class="gantt-bar"
                 class:critical={criticalPathIds.has(t.id)}
@@ -441,7 +464,9 @@
                 class:dragging={dragging?.id === t.id && dragging.armed}
                 class:armed-touch={dragging?.id === t.id && dragging.armed && dragging.pointerType !== 'mouse'}
                 class:dep-mode-target={depMode && depMode.id !== t.id}
-                style={`left:${offsetPx(t.startDate) + (dragging?.id === t.id && dragging.armed ? dragging.previewOffset : 0)}px;width:${widthFor(t)}px;background:${t.color ?? '#3B6CC4'}`}
+                class:verzug-overdue={vs === 'overdue'}
+                class:verzug-clear={vs === 'clear'}
+                style={`left:${offsetPx(t.startDate) + (dragging?.id === t.id && dragging.armed ? dragging.previewOffset : 0)}px;width:${widthFor(t)}px;background:${vs === 'overdue' ? '#C62828' : vs === 'clear' ? '#2E7D32' : (t.color ?? '#3B6CC4')}`}
                 onclick={() => {
                   if (depMode) { applyDepMode(t.id); return; }
                   if (!dragging || !dragging.moved) onSelect?.(t.id);
@@ -461,6 +486,14 @@
                   <span class="tooltip-meta">{t.startDate} → {t.endDate}</span>
                   {#if (t.progressPct ?? 0) > 0}
                     <span class="tooltip-meta">Fortschritt: {t.progressPct}%</span>
+                  {/if}
+                  {#if defectMap.has(t.id)}
+                    {@const dc = defectMap.get(t.id)}
+                    <span class="tooltip-defects" class:overdue={vs === 'overdue'} class:clear={vs === 'clear'}>
+                      {dc?.open ?? 0} offene Mängel / {dc?.total ?? 0} gesamt
+                      {#if vs === 'overdue'} — Verzug!{/if}
+                      {#if vs === 'clear'} — alle erledigt{/if}
+                    </span>
                   {/if}
                   {#if criticalPathIds.has(t.id)}
                     <span class="tooltip-crit">Kritisch — Verzögerung wirkt 1:1 auf Übergabe</span>
@@ -777,6 +810,32 @@
     pointer-events: none;
     z-index: 1;
   }
+  .gantt-bar.verzug-overdue {
+    box-shadow: 0 0 0 2px #C62828, 0 2px 6px rgba(198, 40, 40, .35);
+    animation: verzugPulse 2s ease-in-out infinite;
+  }
+  .gantt-bar.verzug-clear {
+    box-shadow: 0 0 0 1px #2E7D32;
+  }
+  @keyframes verzugPulse {
+    0%   { box-shadow: 0 0 0 2px #C62828, 0 2px 6px rgba(198, 40, 40, .35); }
+    50%  { box-shadow: 0 0 0 4px rgba(198, 40, 40, .5), 0 2px 10px rgba(198, 40, 40, .5); }
+    100% { box-shadow: 0 0 0 2px #C62828, 0 2px 6px rgba(198, 40, 40, .35); }
+  }
+  @media (prefers-reduced-motion: reduce) { .gantt-bar.verzug-overdue { animation: none; } }
+  .tooltip-defects {
+    display: block;
+    margin-top: 4px;
+    padding: 3px 6px;
+    background: rgba(255, 255, 255, .15);
+    border-radius: 4px;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: .02em;
+  }
+  .tooltip-defects.overdue { background: #C62828; color: #fff; }
+  .tooltip-defects.clear { background: #2E7D32; color: #fff; }
   .gantt-bar.dimmed { opacity: 0.32; filter: saturate(0.6); transition: opacity var(--d-std) var(--ease-out-expo); }
   .gantt-bar.dimmed:hover { opacity: 0.7; }
   .tooltip-crit {

--- a/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
@@ -347,6 +347,7 @@
       onDepClick={(id) => (depPopover = parent.deps.find((d) => d.id === id) ?? null)}
       baseline={activeBaseline}
       lookaheadWeeks={lookahead}
+      taskDefectCounts={parent.taskDefectCounts}
     />
   {/if}
 </div>

--- a/tests/unit/task-defect-link.test.ts
+++ b/tests/unit/task-defect-link.test.ts
@@ -88,3 +88,44 @@ describe('taskDefectCounts', () => {
     expect(counts.size).toBe(0);
   });
 });
+
+// Mirrors the verzugStatus logic from Gantt.svelte
+type VerzugTask = { id: string; endDate: string };
+type DefectCounts = { total: number; open: number };
+
+function verzugStatus(t: VerzugTask, defectMap: Map<string, DefectCounts>, today: string): 'overdue' | 'clear' | 'none' {
+  const counts = defectMap.get(t.id);
+  if (!counts || counts.total === 0) return 'none';
+  if (t.endDate < today && counts.open > 0) return 'overdue';
+  if (counts.open === 0) return 'clear';
+  return 'none';
+}
+
+describe('verzugStatus (Verzug-Ampel)', () => {
+  const today = '2026-05-02';
+  const defectMap = new Map<string, DefectCounts>([
+    ['t1', { total: 3, open: 2 }],
+    ['t2', { total: 1, open: 0 }],
+    ['t3', { total: 5, open: 3 }]
+  ]);
+
+  it('returns overdue when task past endDate AND open defects', () => {
+    expect(verzugStatus({ id: 't1', endDate: '2026-04-30' }, defectMap, today)).toBe('overdue');
+  });
+
+  it('returns clear when all defects resolved', () => {
+    expect(verzugStatus({ id: 't2', endDate: '2026-04-30' }, defectMap, today)).toBe('clear');
+  });
+
+  it('returns none when task has no defects', () => {
+    expect(verzugStatus({ id: 't99', endDate: '2026-04-30' }, defectMap, today)).toBe('none');
+  });
+
+  it('returns none when task not yet overdue even with open defects', () => {
+    expect(verzugStatus({ id: 't3', endDate: '2026-06-01' }, defectMap, today)).toBe('none');
+  });
+
+  it('returns clear even when task is overdue but all defects closed', () => {
+    expect(verzugStatus({ id: 't2', endDate: '2026-03-01' }, defectMap, today)).toBe('clear');
+  });
+});


### PR DESCRIPTION
## Summary

- Gantt-Bars werden **rot + Puls-Animation** wenn Termin ueberfaellig UND offene Maengel hat
- Gantt-Bars werden **gruen** wenn alle verknuepften Maengel erledigt
- **Tooltip** erweitert: "N offene Maengel / M gesamt" + Verzug-Warnung
- Keine Migration noetig — nutzt taskDefectCounts aus PR #25
- 5 neue Unit-Tests fuer verzugStatus-Logik (total: 11 Tests)

## Hypothese

Bauleiter sieht im Gantt nur Balken ohne Maengel-Kontext. Bei 150 Terminen unmoeglich sich zu merken welche durch offene Maengel blockiert sind. Verzug wird erst erkannt wenn es zu spaet ist.

**Erfolgsmessung**: Verzug-Erkennung von ~5 Min manuelles Nachschlagen auf sofortige visuelle Erkennung (0 Klicks).

## Test plan

- [ ] Termin mit offenen Maengeln + ueberfaelliges End-Datum: Bar rot mit Puls
- [ ] Termin mit allen Maengeln erledigt: Bar gruen
- [ ] Termin ohne Maengel: normale Farbe
- [ ] Hover-Tooltip zeigt Maengel-Zaehler
- [ ] Mobile (375px): Puls-Animation sichtbar, kein Overflow
- [ ] `pnpm check` + `vitest run` gruen

> Basiert auf PR #25 (Termin-Maengel-Verknuepfung). Bitte zuerst #25 mergen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)