### PR TITLE
feat: Verzug-Ampel + KPI verlorene Tage (re-apply #26 + #27)

### DIFF
--- a/.autopilot/PROPOSALS.md
+++ b/.autopilot/PROPOSALS.md
@@ -74,6 +74,88 @@ Gespräche und VOB-Maßnahmen.
 
 **Status**: Pending (nach Item 2)
 
+---
+
+### V-001: Auto-Verknüpfung Mangel→Termin via Gewerk+Wohnung
+
+**Was:** Wenn ein neuer Mangel erstellt wird und Gewerk + Wohnung gesetzt sind,
+automatisch den passenden Termin vorschlagen (gleiche gewerkId, passender
+Zeitraum). 1-Klick-Bestätigung statt manuelles Dropdown-Suchen.
+**Wert für Bauleiter:** Eliminiert den manuellen Schritt der Termin-Zuordnung.
+Bei 5-10 Mängeln/Tag spart das 2-3 Minuten pro Mangel.
+**Aufwand:** S
+**Migration nötig:** Nein
+**Trade-offs / Risiken:** Falsche Auto-Zuordnung bei mehreren Terminen pro
+Gewerk — deshalb nur Vorschlag, nicht automatisch setzen.
+**Status:** Pending
+
+---
+
+### V-002: Mängel-Filter "nur Mängel die Termin X blockieren"
+
+**Was:** Im Bauzeitenplan ein Klick auf einen rot-markierten Termin zeigt
+direkt die gefilterte Mängel-Liste (nur Mängel mit taskId = diesen Termin).
+Deep-Link vom Gantt-Tooltip in die Mängel-Liste mit vorgesetztem Filter.
+**Wert für Bauleiter:** Direkter Sprung von "dieser Termin ist blockiert" zu
+"das sind die konkreten Mängel die ich lösen muss".
+**Aufwand:** S
+**Migration nötig:** Nein
+**Trade-offs / Risiken:** Keine nennenswerten. Rein clientseitige Filter-Logik.
+**Status:** Pending
+
+---
+
+### V-003: Verzug-Benachrichtigung per Telegram-Bot
+
+**Was:** Täglicher Cronjob prüft alle Termine mit endDate < heute UND offenen
+Mängeln. Sendet Telegram-Push an Bauleiter: "3 Termine in Verzug wegen
+Mängeln: Trockenbau Haus 1 (2 Tage), Elektro Haus 2 (5 Tage), ...".
+**Wert für Bauleiter:** Proaktive Warnung statt reaktive Entdeckung.
+Bauleiter weiß morgens VOR der Fahrt zur Baustelle was kritisch ist.
+**Aufwand:** M
+**Migration nötig:** Nein (nutzt bestehende Telegram-Infrastruktur)
+**Trade-offs / Risiken:** Zu viele Benachrichtigungen könnten nerven.
+Lösung: Schwellenwert (nur ab 2+ Tagen Verzug), Snooze-Funktion.
+**Status:** Pending
+
+---
+
+### V-004: Mangel-Drag-to-Termin im Gantt-Chart
+
+**Was:** Im Bauzeitenplan einen Mangel aus einer Seitenleiste auf einen
+Gantt-Balken ziehen um die Verknüpfung herzustellen. Visuelles,
+schnelles Zuordnen statt Dropdown-Suche im Mangel-Detail.
+**Wert für Bauleiter:** Besonders bei Bulk-Zuordnung nach Baustellenbegehung
+(10-20 Mängel einem Termin zuordnen) deutlich schneller als einzeln öffnen.
+**Aufwand:** M
+**Migration nötig:** Nein
+**Trade-offs / Risiken:** Touch-DnD auf Mobile schwierig (kollidiert mit
+Scroll). Desktop-only Feature oder Mobile-Alternative als Batch-Zuordnung.
+**Status:** Pending
+
+---
+
+### V-005: Folgegewerk-Warnung bei Mangel-Erstellung
+
+**Was:** Wenn ein Mangel einem Termin zugeordnet wird und dieser Termin
+Nachfolger hat (task_dependencies), zeigt die App: "Achtung: Dieser Mangel
+kann Folgegewerk [Maler] um bis zu X Tage verzögern." Basiert auf dem
+Gantt-Engine-Propagationsalgorithmus.
+**Wert für Bauleiter:** Sofortige Konsequenz-Transparenz. Bauleiter versteht
+die Auswirkung eines Mangels auf die Gesamtplanung BEVOR er eskaliert.
+**Aufwand:** M
+**Migration nötig:** Nein (nutzt bestehende task_dependencies + engine.ts)
+**Trade-offs / Risiken:** Kann übermäßig alarmierend wirken. Lösung:
+nur bei Terminen die bereits >80% durch sind oder <7 Tage vor endDate.
+**Status:** Pending
+
 ## Archiv
 
-(Vergangene Vorschlaege mit Approval-Status.)
+### H-001 — Termin-Mängel-Verknüpfung Phase 1
+**Status**: Implementiert (PR #25)
+
+### H-002 — Verzug-Ampel im Bauzeitenplan
+**Status**: Implementiert (PR #26)
+
+### H-003 — KPI verlorene Tage pro Gewerk
+**Status**: Implementiert (PR #27)

--- a/.autopilot/SESSION_SUMMARY.md
+++ b/.autopilot/SESSION_SUMMARY.md
@@ -1,0 +1,39 @@
+# Session Summary — Nacht-Schicht 2026-05-02
+
+## Bilanz
+
+| Item | PR | Status | Migration | Tests |
+|------|-----|--------|-----------|-------|
+| Termin-Mängel-Verknüpfung Phase 1 | #25 | CI grün, wartet auf Review-Approval | 0015 (deployed) | 6 |
+| Verzug-Ampel im Bauzeitenplan | #26 | CI pending, basiert auf #25 | keine | 5 |
+| KPI verlorene Tage pro Gewerk | #27 | CI pending, basiert auf #26 | keine | 5 |
+
+**Gesamt**: 3 PRs, 1 Migration (deployed), 16 Unit-Tests, 0 neue Fehler.
+
+## Merge-Reihenfolge
+
+1. PR #25 mergen (braucht 1 Review-Approval wegen Branch Protection)
+2. PR #26 rebased auf main nach #25-Merge
+3. PR #27 rebased auf main nach #26-Merge
+
+## Technische Details
+
+### PR #25: Termin-Mängel-Verknüpfung
+- Migration 0015: `defects.task_id` FK + Index (bereits auf Supabase deployed)
+- Schema, Backend-Queries, Task-Detail UI (Mängel-Liste), Mangel-Detail UI (Termin-Dropdown + Link)
+- Gewerk-basierte Vorsortierung im Termin-Dropdown
+
+### PR #26: Verzug-Ampel
+- Gantt-Bar rot + Puls wenn überfällig + offene Mängel
+- Gantt-Bar grün wenn alle Mängel erledigt
+- Tooltip mit Mängel-Zähler
+
+### PR #27: KPI verlorene Tage
+- Neuer Bar-Chart im Statistik-Dashboard
+- Server-seitiger JOIN tasks+defects mit GROUP BY
+- Live-Verzug für offene Mängel (zählt bis heute)
+
+## Blockierer
+
+- Branch Protection erfordert 1 Review-Approval. Self-Approval nicht möglich.
+- Laurenz muss PR #25 approven, dann können #26 und #27 folgen.

--- a/.autopilot/TODO_AUTOPILOT.md
+++ b/.autopilot/TODO_AUTOPILOT.md
@@ -10,8 +10,10 @@ Items werden hier von Laurenz oder vom Autopilot selbst (nach Approval) hinzugef
 
 ## Aktive Items
 
-(Liste startet leer. Wenn der Autopilot zum ersten Mal startet ohne hier ein Item zu finden, generiert er Vorschläge in PROPOSALS.md.)
+(Leer — warte auf Approval der neuen Vorschläge in Issue #28.)
 
 ## Erledigte Items (Archiv)
 
-(Wird automatisch gefüllt nach erfolgreichem Merge.)
+1. **Termin-Mängel-Verknüpfung Phase 1** — PR #25, Migration 0015 deployed. [2026-05-02]
+2. **Verzug-Ampel im Bauzeitenplan** — PR #26, keine Migration. [2026-05-02]
+3. **KPI "Wegen Mängeln verlorene Tage pro Gewerk"** — PR #27, keine Migration. [2026-05-02]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,11 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
   Task-Detail zeigt verknüpfte Mängel-Liste (1 Klick statt 6-8).
   Mangel-Detail zeigt zugehörigen Termin mit Plan-Ende-Datum und
   Direktlink. Gewerk-basierte Termin-Vorschläge im Dropdown.
-  Migration 0015 (additive, task_id + Index). (PR #TBD)
+  Migration 0015 (additive, task_id + Index). (PR #25)
+- feat(verzug-ampel): Gantt-Bars werden rot wenn Termin ueberfaellig
+  UND offene Maengel hat, gruen wenn alle erledigt. Tooltip zeigt
+  "N offene Maengel / M gesamt" mit Verzug-Warnung. Sofortige
+  visuelle Erkennung statt manuelles Nachschlagen. (PR #TBD)
 
 ### Fixed
 - 🔥 **HOTFIX** fix(maengel/perf): Mängel-Seite lief in

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,11 @@ Human-readable feature log. Eine Zeile pro merklicher Änderung.
 - feat(verzug-ampel): Gantt-Bars werden rot wenn Termin ueberfaellig
   UND offene Maengel hat, gruen wenn alle erledigt. Tooltip zeigt
   "N offene Maengel / M gesamt" mit Verzug-Warnung. Sofortige
-  visuelle Erkennung statt manuelles Nachschlagen. (PR #TBD)
+  visuelle Erkennung statt manuelles Nachschlagen. (PR #26)
+- feat(kpi): KPI "Wegen Maengeln verlorene Tage pro Gewerk" im
+  Statistik-Dashboard. Bar-Chart zeigt Differenz Plan-Ende vs.
+  tatsaechliches Erledigt-Datum, aggregiert pro Gewerk.
+  Datenbasierte Aussage statt Bauchgefuehl. (PR #TBD)
 
 ### Fixed
 - 🔥 **HOTFIX** fix(maengel/perf): Mängel-Seite lief in

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,9 +1,14 @@
 # PROGRESS
 
 **Nacht-Session 2026-05-02** (Autopilot):
-- PR #TBD: Termin-Mängel-Verknüpfung Phase 1 — defects.task_id FK,
+- PR #25: Termin-Mängel-Verknüpfung Phase 1 — defects.task_id FK,
   bidirektionale UI (Task zeigt Mängel, Mangel zeigt Termin),
   Migration 0015, 6 Unit-Tests
+- PR #26: Verzug-Ampel im Bauzeitenplan — rot/grün Gantt-Bars,
+  Tooltip mit Mängel-Zähler, 5 Unit-Tests
+- PR #27: KPI verlorene Tage pro Gewerk — Bar-Chart im Statistik-
+  Dashboard, Live-Verzug-Tracking, 5 Unit-Tests
+- Issue #28: 5 Vorschläge für nächste Iteration
 
 **post-rc2 Session** (davor):
 - PR #5 (gemerged): /checklisten FROM-clause-Fix

--- a/src/lib/components/Gantt.svelte
+++ b/src/lib/components/Gantt.svelte
@@ -14,6 +14,8 @@
     progressPct?: number;
   };
 
+  type TaskDefectCount = { taskId: string | null; total: number; open: number };
+
   type Baseline = { taskId: string; plannedStart: string; plannedEnd: string };
   export type Dependency = {
     id: string;
@@ -33,6 +35,7 @@
     baseline?: Baseline[];
     dependencies?: Dependency[];
     lookaheadWeeks?: 0 | 3 | 4 | 6;
+    taskDefectCounts?: TaskDefectCount[];
   };
   let {
     tasks,
@@ -43,8 +46,27 @@
     criticalPathIds = new Set<string>(),
     baseline = [],
     dependencies = [],
-    lookaheadWeeks = 0
+    lookaheadWeeks = 0,
+    taskDefectCounts = []
   }: Props = $props();
+
+  /* ===== Verzug-Ampel: task overdue + open defects = red, all resolved = green ===== */
+  let defectMap = $derived.by(() => {
+    const m = new Map<string, { total: number; open: number }>();
+    for (const c of taskDefectCounts) {
+      if (c.taskId) m.set(c.taskId, { total: c.total, open: c.open });
+    }
+    return m;
+  });
+
+  function verzugStatus(t: GTask): 'overdue' | 'clear' | 'none' {
+    const counts = defectMap.get(t.id);
+    if (!counts || counts.total === 0) return 'none';
+    const today = fmtDate(new Date());
+    if (t.endDate < today && counts.open > 0) return 'overdue';
+    if (counts.open === 0) return 'clear';
+    return 'none';
+  }
 
   let baselineMap = $derived.by(() => {
     const m = new Map<string, { plannedStart: string; plannedEnd: string }>();
@@ -434,6 +456,7 @@
             {#if isParentMap.has(t.id)}
               <div class="gantt-bar summary" style={`left:${offsetPx(t.startDate)}px;width:${widthFor(t)}px`}></div>
             {:else}
+              {@const vs = verzugStatus(t)}
               <button
                 class="gantt-bar"
                 class:critical={criticalPathIds.has(t.id)}
@@ -441,7 +464,9 @@
                 class:dragging={dragging?.id === t.id && dragging.armed}
                 class:armed-touch={dragging?.id === t.id && dragging.armed && dragging.pointerType !== 'mouse'}
                 class:dep-mode-target={depMode && depMode.id !== t.id}
-                style={`left:${offsetPx(t.startDate) + (dragging?.id === t.id && dragging.armed ? dragging.previewOffset : 0)}px;width:${widthFor(t)}px;background:${t.color ?? '#3B6CC4'}`}
+                class:verzug-overdue={vs === 'overdue'}
+                class:verzug-clear={vs === 'clear'}
+                style={`left:${offsetPx(t.startDate) + (dragging?.id === t.id && dragging.armed ? dragging.previewOffset : 0)}px;width:${widthFor(t)}px;background:${vs === 'overdue' ? '#C62828' : vs === 'clear' ? '#2E7D32' : (t.color ?? '#3B6CC4')}`}
                 onclick={() => {
                   if (depMode) { applyDepMode(t.id); return; }
                   if (!dragging || !dragging.moved) onSelect?.(t.id);
@@ -461,6 +486,14 @@
                   <span class="tooltip-meta">{t.startDate} → {t.endDate}</span>
                   {#if (t.progressPct ?? 0) > 0}
                     <span class="tooltip-meta">Fortschritt: {t.progressPct}%</span>
+                  {/if}
+                  {#if defectMap.has(t.id)}
+                    {@const dc = defectMap.get(t.id)}
+                    <span class="tooltip-defects" class:overdue={vs === 'overdue'} class:clear={vs === 'clear'}>
+                      {dc?.open ?? 0} offene Mängel / {dc?.total ?? 0} gesamt
+                      {#if vs === 'overdue'} — Verzug!{/if}
+                      {#if vs === 'clear'} — alle erledigt{/if}
+                    </span>
                   {/if}
                   {#if criticalPathIds.has(t.id)}
                     <span class="tooltip-crit">Kritisch — Verzögerung wirkt 1:1 auf Übergabe</span>
@@ -777,6 +810,32 @@
     pointer-events: none;
     z-index: 1;
   }
+  .gantt-bar.verzug-overdue {
+    box-shadow: 0 0 0 2px #C62828, 0 2px 6px rgba(198, 40, 40, .35);
+    animation: verzugPulse 2s ease-in-out infinite;
+  }
+  .gantt-bar.verzug-clear {
+    box-shadow: 0 0 0 1px #2E7D32;
+  }
+  @keyframes verzugPulse {
+    0%   { box-shadow: 0 0 0 2px #C62828, 0 2px 6px rgba(198, 40, 40, .35); }
+    50%  { box-shadow: 0 0 0 4px rgba(198, 40, 40, .5), 0 2px 10px rgba(198, 40, 40, .5); }
+    100% { box-shadow: 0 0 0 2px #C62828, 0 2px 6px rgba(198, 40, 40, .35); }
+  }
+  @media (prefers-reduced-motion: reduce) { .gantt-bar.verzug-overdue { animation: none; } }
+  .tooltip-defects {
+    display: block;
+    margin-top: 4px;
+    padding: 3px 6px;
+    background: rgba(255, 255, 255, .15);
+    border-radius: 4px;
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: .02em;
+  }
+  .tooltip-defects.overdue { background: #C62828; color: #fff; }
+  .tooltip-defects.clear { background: #2E7D32; color: #fff; }
   .gantt-bar.dimmed { opacity: 0.32; filter: saturate(0.6); transition: opacity var(--d-std) var(--ease-out-expo); }
   .gantt-bar.dimmed:hover { opacity: 0.7; }
   .tooltip-crit {

--- a/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
@@ -347,6 +347,7 @@
       onDepClick={(id) => (depPopover = parent.deps.find((d) => d.id === id) ?? null)}
       baseline={activeBaseline}
       lookaheadWeeks={lookahead}
+      taskDefectCounts={parent.taskDefectCounts}
     />
   {/if}
 </div>

--- a/src/routes/(app)/[projectId]/maengel/statistik/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/statistik/+page.server.ts
@@ -1,11 +1,11 @@
 import type { PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
-import { defects, gewerke, contacts } from '$lib/db/schema';
-import { eq, sql } from 'drizzle-orm';
+import { defects, gewerke, contacts, tasks } from '$lib/db/schema';
+import { eq, and, sql } from 'drizzle-orm';
 
 export const load: PageServerLoad = async ({ params }) => {
-  if (!db) return { rows: [], gewerkRows: [], contactRows: [] };
-  const [rows, gewerkRows, contactRows] = await Promise.all([
+  if (!db) return { rows: [], gewerkRows: [], contactRows: [], lostDaysData: [] };
+  const [rows, gewerkRows, contactRows, lostDaysData] = await Promise.all([
     db
       .select({
         id: defects.id,
@@ -23,7 +23,19 @@ export const load: PageServerLoad = async ({ params }) => {
     db
       .select({ id: contacts.id, company: contacts.company })
       .from(contacts)
-      .where(sql`${contacts.projectId} = ${params.projectId} OR ${contacts.projectId} IS NULL`)
+      .where(sql`${contacts.projectId} = ${params.projectId} OR ${contacts.projectId} IS NULL`),
+    // Lost days: for each task with linked defects, calculate delay
+    db.select({
+      taskId: tasks.id,
+      taskEndDate: tasks.endDate,
+      gewerkId: tasks.gewerkId,
+      latestResolvedAt: sql<string | null>`max(${defects.resolvedAt})::text`,
+      openCount: sql<number>`count(*) FILTER (WHERE ${defects.status} NOT IN ('resolved', 'accepted', 'rejected'))::int`
+    })
+      .from(tasks)
+      .innerJoin(defects, eq(defects.taskId, tasks.id))
+      .where(eq(tasks.projectId, params.projectId))
+      .groupBy(tasks.id, tasks.endDate, tasks.gewerkId)
   ]);
-  return { rows, gewerkRows, contactRows };
+  return { rows, gewerkRows, contactRows, lostDaysData };
 };

--- a/src/routes/(app)/[projectId]/maengel/statistik/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/statistik/+page.svelte
@@ -101,6 +101,35 @@
     return { out, max };
   });
 
+  // KPI: Lost days per Gewerk (Verzug wegen Mängeln)
+  let lostDaysPerGewerk = $derived.by(() => {
+    const gewerkDays = new Map<string | null, number>();
+    for (const row of parent.lostDaysData ?? []) {
+      // If still open defects: count from task endDate to today
+      // If all resolved: count from task endDate to latest resolvedAt
+      const taskEnd = new Date(row.taskEndDate).getTime();
+      let actualEnd: number;
+      if (row.openCount > 0) {
+        actualEnd = Date.now();
+      } else if (row.latestResolvedAt) {
+        actualEnd = new Date(row.latestResolvedAt).getTime();
+      } else {
+        continue;
+      }
+      const diffDays = Math.max(0, Math.round((actualEnd - taskEnd) / (1000 * 60 * 60 * 24)));
+      if (diffDays <= 0) continue;
+      gewerkDays.set(row.gewerkId, (gewerkDays.get(row.gewerkId) ?? 0) + diffDays);
+    }
+    const entries = Array.from(gewerkDays.entries())
+      .map(([id, days]) => {
+        const g = parent.gewerkRows.find((x) => x.id === id);
+        return { id, name: g?.name ?? '— ohne Gewerk —', color: g?.color ?? '#9CA3AF', days };
+      })
+      .sort((a, b) => b.days - a.days);
+    const max = entries[0]?.days ?? 1;
+    return { entries, max };
+  });
+
   const STATUS_LABEL: Record<string, string> = {
     open: 'Offen', sent: 'Gesendet', acknowledged: 'Bestätigt',
     resolved: 'Erledigt', accepted: 'Akzeptiert', rejected: 'Abgelehnt', reopened: 'Wiedereröffnet'
@@ -206,6 +235,26 @@
         </div>
       {/if}
     </div>
+
+    <div class="chart-card chart-card-wide">
+      <h3 class="chart-title">Wegen Mängeln verlorene Tage pro Gewerk</h3>
+      {#if lostDaysPerGewerk.entries.length === 0}
+        <p class="chart-empty">Keine Verzugsdaten. Verknüpfe Mängel mit Terminen im Bauzeitenplan.</p>
+      {:else}
+        <div class="bar-list">
+          {#each lostDaysPerGewerk.entries as e (e.id)}
+            <div class="bar-row">
+              <span class="bar-label">{e.name}</span>
+              <span class="bar-track">
+                <span class="bar-fill bar-fill-red" style={`width:${(e.days / lostDaysPerGewerk.max) * 100}%`}></span>
+              </span>
+              <span class="bar-count">{e.days}<span class="bar-unit">d</span></span>
+            </div>
+          {/each}
+        </div>
+        <p class="chart-hint">Differenz zwischen Plan-Ende des Termins und tatsächlichem Erledigt-Datum aller zugeordneten Mängel. Offene Mängel zählen bis heute.</p>
+      {/if}
+    </div>
   </div>
 </div>
 
@@ -241,4 +290,7 @@
   .status-count { font-family: var(--mono); font-weight: 700; }
   .line-chart { width: 100%; height: 200px; display: block; }
   .line-axis { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 10px; color: var(--muted); margin-top: 4px; padding: 0 4px; }
+  .bar-fill-red { background: var(--red, #E30613) !important; }
+  .bar-unit { font-size: 9px; color: var(--muted); margin-left: 1px; }
+  .chart-hint { font-family: var(--mono); font-size: 10px; color: var(--muted); margin: 10px 0 0; line-height: 1.4; }
 </style>

--- a/tests/unit/task-defect-link.test.ts
+++ b/tests/unit/task-defect-link.test.ts
@@ -88,3 +88,44 @@ describe('taskDefectCounts', () => {
     expect(counts.size).toBe(0);
   });
 });
+
+// Mirrors the verzugStatus logic from Gantt.svelte
+type VerzugTask = { id: string; endDate: string };
+type DefectCounts = { total: number; open: number };
+
+function verzugStatus(t: VerzugTask, defectMap: Map<string, DefectCounts>, today: string): 'overdue' | 'clear' | 'none' {
+  const counts = defectMap.get(t.id);
+  if (!counts || counts.total === 0) return 'none';
+  if (t.endDate < today && counts.open > 0) return 'overdue';
+  if (counts.open === 0) return 'clear';
+  return 'none';
+}
+
+describe('verzugStatus (Verzug-Ampel)', () => {
+  const today = '2026-05-02';
+  const defectMap = new Map<string, DefectCounts>([
+    ['t1', { total: 3, open: 2 }],
+    ['t2', { total: 1, open: 0 }],
+    ['t3', { total: 5, open: 3 }]
+  ]);
+
+  it('returns overdue when task past endDate AND open defects', () => {
+    expect(verzugStatus({ id: 't1', endDate: '2026-04-30' }, defectMap, today)).toBe('overdue');
+  });
+
+  it('returns clear when all defects resolved', () => {
+    expect(verzugStatus({ id: 't2', endDate: '2026-04-30' }, defectMap, today)).toBe('clear');
+  });
+
+  it('returns none when task has no defects', () => {
+    expect(verzugStatus({ id: 't99', endDate: '2026-04-30' }, defectMap, today)).toBe('none');
+  });
+
+  it('returns none when task not yet overdue even with open defects', () => {
+    expect(verzugStatus({ id: 't3', endDate: '2026-06-01' }, defectMap, today)).toBe('none');
+  });
+
+  it('returns clear even when task is overdue but all defects closed', () => {
+    expect(verzugStatus({ id: 't2', endDate: '2026-03-01' }, defectMap, today)).toBe('clear');
+  });
+});

--- a/tests/unit/task-defect-link.test.ts
+++ b/tests/unit/task-defect-link.test.ts
@@ -129,3 +129,67 @@ describe('verzugStatus (Verzug-Ampel)', () => {
     expect(verzugStatus({ id: 't2', endDate: '2026-03-01' }, defectMap, today)).toBe('clear');
   });
 });
+
+// Mirrors the lostDaysPerGewerk logic from statistik page
+type LostDaysRow = { taskId: string; taskEndDate: string; gewerkId: string | null; latestResolvedAt: string | null; openCount: number };
+
+function calcLostDaysPerGewerk(rows: LostDaysRow[], today: Date): Map<string | null, number> {
+  const gewerkDays = new Map<string | null, number>();
+  for (const row of rows) {
+    const taskEnd = new Date(row.taskEndDate).getTime();
+    let actualEnd: number;
+    if (row.openCount > 0) {
+      actualEnd = today.getTime();
+    } else if (row.latestResolvedAt) {
+      actualEnd = new Date(row.latestResolvedAt).getTime();
+    } else {
+      continue;
+    }
+    const diffDays = Math.max(0, Math.round((actualEnd - taskEnd) / (1000 * 60 * 60 * 24)));
+    if (diffDays <= 0) continue;
+    gewerkDays.set(row.gewerkId, (gewerkDays.get(row.gewerkId) ?? 0) + diffDays);
+  }
+  return gewerkDays;
+}
+
+describe('calcLostDaysPerGewerk (KPI)', () => {
+  const today = new Date('2026-05-02');
+
+  it('calculates delay for tasks with resolved defects past endDate', () => {
+    const rows: LostDaysRow[] = [
+      { taskId: 't1', taskEndDate: '2026-04-20', gewerkId: 'g1', latestResolvedAt: '2026-04-25T10:00:00Z', openCount: 0 }
+    ];
+    const result = calcLostDaysPerGewerk(rows, today);
+    expect(result.get('g1')).toBe(5); // Apr 20 -> Apr 25 = 5 days
+  });
+
+  it('uses today for tasks with still-open defects', () => {
+    const rows: LostDaysRow[] = [
+      { taskId: 't1', taskEndDate: '2026-04-30', gewerkId: 'g1', latestResolvedAt: null, openCount: 2 }
+    ];
+    const result = calcLostDaysPerGewerk(rows, today);
+    expect(result.get('g1')).toBe(2); // Apr 30 -> May 2 = 2 days
+  });
+
+  it('ignores tasks where defects resolved before endDate', () => {
+    const rows: LostDaysRow[] = [
+      { taskId: 't1', taskEndDate: '2026-05-10', gewerkId: 'g1', latestResolvedAt: '2026-05-05T10:00:00Z', openCount: 0 }
+    ];
+    const result = calcLostDaysPerGewerk(rows, today);
+    expect(result.has('g1')).toBe(false); // No delay
+  });
+
+  it('aggregates across multiple tasks per gewerk', () => {
+    const rows: LostDaysRow[] = [
+      { taskId: 't1', taskEndDate: '2026-04-20', gewerkId: 'g1', latestResolvedAt: '2026-04-25T00:00:00Z', openCount: 0 },
+      { taskId: 't2', taskEndDate: '2026-04-22', gewerkId: 'g1', latestResolvedAt: '2026-04-29T00:00:00Z', openCount: 0 }
+    ];
+    const result = calcLostDaysPerGewerk(rows, today);
+    expect(result.get('g1')).toBe(12); // 5 + 7
+  });
+
+  it('returns empty map when no delays', () => {
+    const result = calcLostDaysPerGewerk([], today);
+    expect(result.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Re-apply von PR #26 (Verzug-Ampel) und PR #27 (KPI verlorene Tage) auf main.
Die Original-PRs wurden beim Merge von #25 durch GitHub auto-closed aber deren
Commits landeten nicht auf main.

### Verzug-Ampel im Bauzeitenplan
- Gantt-Bars werden **rot + Puls** wenn Termin ueberfaellig UND offene Maengel
- Gantt-Bars werden **gruen** wenn alle verknuepften Maengel erledigt
- Tooltip mit Maengel-Zaehler

### KPI verlorene Tage pro Gewerk
- Neuer Bar-Chart im Statistik-Dashboard
- Differenz Plan-Ende vs. Erledigt-Datum, aggregiert pro Gewerk
- Offene Maengel zaehlen bis heute (live Verzug)

### Session-Docs
- SESSION_SUMMARY.md, PROPOSALS.md mit 5 neuen Vorschlaegen, TODO-Archiv

**16 Unit-Tests, keine Migration, keine neuen Type-Errors.**

## Test plan

- [ ] Gantt: Termin ueberfaellig + offene Maengel = rot
- [ ] Gantt: alle Maengel erledigt = gruen
- [ ] Statistik: KPI-Chart sichtbar mit Verzugsdaten
- [ ] Mobile (375px): alles lesbar
- [ ] `pnpm check` + `vitest run` gruen

🤖 Generated with [Claude Code](https://claude.com/claude-code)