### PR TITLE
feat: Kalender-Ausnahmen (Betriebsferien, Sperrungen)

### DIFF
--- a/src/lib/components/Gantt.svelte
+++ b/src/lib/components/Gantt.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { parseDate, addDays, daysBetween, fmtDate, isNonWorkday, holidayName } from '$lib/gantt/calendar';
+  import { parseDate, addDays, daysBetween, fmtDate, isNonWorkdayFull, holidayName } from '$lib/gantt/calendar';
 
   type GTask = {
     id: string;
@@ -169,7 +169,7 @@
     const end = parseDate(range.end);
     const cur = new Date(start);
     while (cur <= end) {
-      if (isNonWorkday(cur)) {
+      if (isNonWorkdayFull(cur)) {
         const left = daysBetween(range.start, fmtDate(cur)) * dayWidth();
         out.push({ left, width: dayWidth(), holiday: holidayName(cur) });
       }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -446,6 +446,18 @@ export const defectTemplates = pgTable('defect_templates', {
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
 });
 
+/* ----- Calendar Exceptions (Betriebsferien, Sperrungen) ----- */
+
+export const calendarExceptions = pgTable('calendar_exceptions', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  projectId: uuid('project_id').notNull().references(() => projects.id, { onDelete: 'cascade' }),
+  date: date('date').notNull(),
+  type: text('type', { enum: ['holiday', 'workday'] }).notNull(),
+  label: text('label'),
+  createdBy: uuid('created_by').references(() => profiles.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull()
+});
+
 /* ----- Activity feed ----- */
 
 export const activity = pgTable('activity', {

--- a/src/lib/gantt/calendar.ts
+++ b/src/lib/gantt/calendar.ts
@@ -123,6 +123,28 @@ export function holidayName(d: Date): string | null {
   return null;
 }
 
+/* ===== Project-level exceptions (set from server data) ===== */
+let projectHolidays = new Set<string>(); // extra non-work days
+let projectWorkdays = new Set<string>(); // force-work days (e.g. Saturday)
+
+export function setProjectExceptions(holidays: string[], workdays: string[]) {
+  projectHolidays = new Set(holidays);
+  projectWorkdays = new Set(workdays);
+}
+
+export function clearProjectExceptions() {
+  projectHolidays = new Set();
+  projectWorkdays = new Set();
+}
+
+/** Full non-workday check: weekend OR holiday OR project-holiday, MINUS project-workday overrides. */
+export function isNonWorkdayFull(d: Date): boolean {
+  const iso = fmtDate(d);
+  if (projectWorkdays.has(iso)) return false; // explicit workday override
+  if (projectHolidays.has(iso)) return true; // project holiday
+  return isNonWorkday(d); // weekend or BW holiday
+}
+
 export function addWorkingDays(start: string, n: number): string {
   if (n === 0) return start;
   const dir = n > 0 ? 1 : -1;
@@ -130,7 +152,7 @@ export function addWorkingDays(start: string, n: number): string {
   const d = parseDate(start);
   while (remaining > 0) {
     d.setDate(d.getDate() + dir);
-    if (!isNonWorkday(d)) remaining--;
+    if (!isNonWorkdayFull(d)) remaining--;
   }
   return fmtDate(d);
 }
@@ -143,7 +165,7 @@ export function workingDaysBetween(a: string, b: string): number {
   const end = parseDate(b);
   while ((dir > 0 && d < end) || (dir < 0 && d > end)) {
     d.setDate(d.getDate() + dir);
-    if (!isNonWorkday(d)) count++;
+    if (!isNonWorkdayFull(d)) count++;
   }
   return count * dir;
 }

--- a/src/routes/(app)/[projectId]/bauzeitenplan/+page.server.ts
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/+page.server.ts
@@ -2,7 +2,7 @@ import { redirect, fail } from '@sveltejs/kit';
 import { z } from 'zod';
 import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
-import { tasks, taskBaselines, taskDependencies, gewerke, houses, apartments, activity, defects } from '$lib/db/schema';
+import { tasks, taskBaselines, taskDependencies, gewerke, houses, apartments, activity, defects, calendarExceptions } from '$lib/db/schema';
 import { eq, and, asc, desc, or, sql } from 'drizzle-orm';
 import { loadGaisbachSample } from '$lib/db/projectQueries';
 import { getProjectTasksAndDeps, applyTaskUpdates } from '$lib/db/taskQueries';
@@ -10,7 +10,7 @@ import { propagate, type EngineTask, type EngineDep } from '$lib/gantt/engine';
 
 export const load: PageServerLoad = async ({ params }) => {
   const { tasks: tRows, deps } = await getProjectTasksAndDeps(params.projectId);
-  if (!db) return { tasks: tRows, deps, gewerke: [], houses: [], baselineLabels: [], taskDefectCounts: [] };
+  if (!db) return { tasks: tRows, deps, gewerke: [], houses: [], baselineLabels: [], taskDefectCounts: [], calExceptions: [] };
 
   const [gewerkeRows, houseRows, taskDefectCounts] = await Promise.all([
     db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)),
@@ -47,7 +47,12 @@ export const load: PageServerLoad = async ({ params }) => {
     baselineLabels.push({ label: r.label, snapshotAt: r.snapshotAt });
   }
 
-  return { tasks: tRows, deps, gewerke: gewerkeRows, houses: houseTree, baselineLabels, taskDefectCounts };
+  const calExceptions = await db
+    .select({ date: calendarExceptions.date, type: calendarExceptions.type, label: calendarExceptions.label })
+    .from(calendarExceptions)
+    .where(eq(calendarExceptions.projectId, params.projectId));
+
+  return { tasks: tRows, deps, gewerke: gewerkeRows, houses: houseTree, baselineLabels, taskDefectCounts, calExceptions };
 };
 
 const moveSchema = z.object({
@@ -359,5 +364,49 @@ export const actions: Actions = {
     });
 
     return { ok: true, taskId: row.id };
+  },
+
+  addCalException: async ({ request, params, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const schema = z.object({
+      date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+      type: z.enum(['holiday', 'workday']),
+      label: z.string().max(100).optional().or(z.literal(''))
+    });
+    const parsed = schema.safeParse(fd);
+    if (!parsed.success) return fail(400, { error: 'Ungültige Eingabe.' });
+
+    // Upsert: bei Duplikat den Typ aktualisieren
+    const existing = await db
+      .select()
+      .from(calendarExceptions)
+      .where(and(eq(calendarExceptions.projectId, params.projectId), eq(calendarExceptions.date, parsed.data.date)))
+      .limit(1);
+
+    if (existing.length > 0) {
+      await db.update(calendarExceptions)
+        .set({ type: parsed.data.type, label: parsed.data.label || null })
+        .where(eq(calendarExceptions.id, existing[0].id));
+    } else {
+      await db.insert(calendarExceptions).values({
+        projectId: params.projectId,
+        date: parsed.data.date,
+        type: parsed.data.type,
+        label: parsed.data.label || null,
+        createdBy: locals.user.id
+      });
+    }
+    return { ok: true };
+  },
+
+  removeCalException: async ({ request, params, locals }) => {
+    if (!locals.user || !db) return fail(401);
+    const fd = Object.fromEntries(await request.formData());
+    const date = String(fd.date ?? '');
+    if (!date) return fail(400);
+    await db.delete(calendarExceptions)
+      .where(and(eq(calendarExceptions.projectId, params.projectId), eq(calendarExceptions.date, date)));
+    return { ok: true };
   }
 };

--- a/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/+page.svelte
@@ -5,12 +5,21 @@
   import { invalidateAll, goto } from '$app/navigation';
   import { page } from '$app/state';
   import { criticalPath, calculateFloat, type EngineTask, type EngineDep } from '$lib/gantt/engine';
-  import { fmtDate } from '$lib/gantt/calendar';
+  import { fmtDate, setProjectExceptions } from '$lib/gantt/calendar';
   import { toast } from '$lib/components/Toast.svelte';
   import { confirm } from '$lib/components/ConfirmDialog.svelte';
 
   let { data } = $props();
   let parent = $derived(data);
+
+  // Set project calendar exceptions
+  $effect(() => {
+    const exc = parent.calExceptions ?? [];
+    setProjectExceptions(
+      exc.filter(e => e.type === 'holiday').map(e => e.date),
+      exc.filter(e => e.type === 'workday').map(e => e.date)
+    );
+  });
 
   let selected = $state<string | null>(null);
   let selectedTask = $derived(parent.tasks.find((t) => t.id === selected) ?? null);

--- a/supabase/migrations/0017_calendar_exceptions.sql
+++ b/supabase/migrations/0017_calendar_exceptions.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- 0017_calendar_exceptions
+-- Project-level calendar exceptions (Betriebsferien, Sperrungen,
+-- Samstag als Arbeitstag). Additive, idempotent, transactional.
+-- ============================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.calendar_exceptions (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id  uuid NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  date        date NOT NULL,
+  type        text NOT NULL CHECK (type IN ('holiday', 'workday')),
+  label       text,
+  created_by  uuid REFERENCES public.profiles(id),
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS cal_exc_project_date_idx
+  ON public.calendar_exceptions(project_id, date);
+
+CREATE INDEX IF NOT EXISTS cal_exc_project_idx
+  ON public.calendar_exceptions(project_id);
+
+ALTER TABLE public.calendar_exceptions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "cal_exc read members" ON public.calendar_exceptions;
+CREATE POLICY "cal_exc read members" ON public.calendar_exceptions
+  FOR SELECT TO authenticated
+  USING (public.is_project_member(project_id));
+
+DROP POLICY IF EXISTS "cal_exc write members" ON public.calendar_exceptions;
+CREATE POLICY "cal_exc write members" ON public.calendar_exceptions
+  FOR ALL TO authenticated
+  USING (public.is_project_member(project_id))
+  WITH CHECK (public.is_project_member(project_id));
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Migration 0017: calendar_exceptions Tabelle mit RLS
- Projekt-spezifische Feiertage und Arbeitstage definierbar
- Alle Datums-Berechnungen (addWorkingDays, engine) respektieren Exceptions
- Gantt visualisiert Ausnahmen mit Schraffur
- Server-Actions: addCalException, removeCalException

## Test plan
- [ ] Migration deployen
- [ ] Kalender-Ausnahme hinzufuegen (z.B. Betriebsferien 23.12-06.01)
- [ ] Gantt zeigt Ausnahme-Tag mit Schraffur
- [ ] Terminberechnung ueberspringt Ausnahme-Tage
- [ ] `vitest run` gruen (60 Tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)