### PR TITLE
feat: Folgegewerk-Warnung bei Mangel-Zuordnung

### DIFF
--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.server.ts
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.server.ts
@@ -2,7 +2,7 @@ import { error, fail } from '@sveltejs/kit';
 import { z } from 'zod';
 import type { Actions, PageServerLoad } from './$types';
 import { db } from '$lib/db/client';
-import { defectPhotos, defectHistory, gewerke, contacts, textbausteine, tasks } from '$lib/db/schema';
+import { defectPhotos, defectHistory, gewerke, contacts, textbausteine, tasks, taskDependencies } from '$lib/db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { getDefect, updateDefectFields, listContactsForProject } from '$lib/db/defectQueries';
 import { listVorgaenge, addVorgang, listBriefVorlagen, getFirmaSettings } from '$lib/db/vorgangQueries';
@@ -10,9 +10,9 @@ import { listVorgaenge, addVorgang, listBriefVorlagen, getFirmaSettings } from '
 export const load: PageServerLoad = async ({ params }) => {
   const detail = await getDefect(params.projectId, params.defectId);
   if (!detail) error(404, 'Mangel nicht gefunden');
-  if (!db) return { ...detail, gewerke: [], contacts: [], textbausteine: [], vorgaenge: [], briefVorlagen: [], firma: null, projectTasks: [] };
+  if (!db) return { ...detail, gewerke: [], contacts: [], textbausteine: [], vorgaenge: [], briefVorlagen: [], firma: null, projectTasks: [], taskDeps: [] };
 
-  const [gewerkeRows, contactsRows, textRows, vorgaenge, briefVorlagen, firma, projectTasks] = await Promise.all([
+  const [gewerkeRows, contactsRows, textRows, vorgaenge, briefVorlagen, firma, projectTasks, taskDeps] = await Promise.all([
     db.select().from(gewerke).orderBy(asc(gewerke.sortOrder)),
     listContactsForProject(params.projectId),
     db.select().from(textbausteine).orderBy(asc(textbausteine.sortOrder)),
@@ -22,7 +22,9 @@ export const load: PageServerLoad = async ({ params }) => {
     db.select({ id: tasks.id, name: tasks.name, num: tasks.num, gewerkId: tasks.gewerkId, endDate: tasks.endDate })
       .from(tasks)
       .where(eq(tasks.projectId, params.projectId))
-      .orderBy(asc(tasks.sortOrder))
+      .orderBy(asc(tasks.sortOrder)),
+    db.select({ predecessorId: taskDependencies.predecessorId, successorId: taskDependencies.successorId, type: taskDependencies.type })
+      .from(taskDependencies)
   ]);
 
   return {
@@ -33,7 +35,8 @@ export const load: PageServerLoad = async ({ params }) => {
     vorgaenge,
     briefVorlagen,
     firma,
-    projectTasks
+    projectTasks,
+    taskDeps
   };
 };
 

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
@@ -158,6 +158,31 @@
     const rest = all.filter((t) => t.gewerkId !== gewerkId);
     return [...matching, ...rest];
   });
+  // Folgegewerk-Warnung: wenn dieser Mangel einem Termin zugeordnet ist
+  // und dieser Termin Nachfolger hat, zeige welche Gewerke betroffen sind
+  let folgewerkWarnung = $derived.by(() => {
+    if (!taskId) return null;
+    const deps = parent.taskDeps ?? [];
+    const allTasks = parent.projectTasks ?? [];
+    const gewerkeList = parent.gewerke ?? [];
+
+    // Finde direkte Nachfolger des zugeordneten Termins
+    const successorIds = deps.filter(d => d.predecessorId === taskId).map(d => d.successorId);
+    if (successorIds.length === 0) return null;
+
+    const successors = allTasks
+      .filter(t => successorIds.includes(t.id))
+      .map(t => {
+        const g = gewerkeList.find(g => g.id === t.gewerkId);
+        return { name: t.name, gewerk: g?.name ?? null };
+      });
+
+    if (successors.length === 0) return null;
+
+    const namen = successors.map(s => s.gewerk ?? s.name).join(', ');
+    return `Achtung: Dieser Mangel kann ${successors.length === 1 ? 'Folgegewerk' : 'Folgegewerke'} ${namen} verzögern.`;
+  });
+
   let deadline = $state(data.defect.deadline ?? '');
   let followupDate = $state(data.defect.followupDate ?? '');
   let priority = $state(String(data.defect.priority ?? 2));
@@ -434,6 +459,12 @@
         <span class="task-link-arrow">→</span>
       </a>
     {/if}
+    {#if folgewerkWarnung}
+      <div class="folgewerk-warnung">
+        <span class="folgewerk-icon">⚠️</span>
+        <span>{folgewerkWarnung}</span>
+      </div>
+    {/if}
   </div>
 
   <h3 class="section-title">Fotos <span class="count">{parent.photos.length}</span></h3>
@@ -664,4 +695,12 @@
   .task-link-name { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .task-link-date { font-family: var(--mono); font-size: 11px; color: var(--muted); }
   .task-link-arrow { font-size: 14px; color: var(--muted); flex-shrink: 0; }
+  .folgewerk-warnung {
+    display: flex; align-items: flex-start; gap: 8px;
+    margin-top: 8px; padding: 10px 12px;
+    background: rgba(217, 119, 6, .08); border: 1px solid rgba(217, 119, 6, .25);
+    border-radius: var(--r-md); font-size: 13px; line-height: 1.4;
+    color: var(--ink);
+  }
+  .folgewerk-icon { font-size: 16px; flex-shrink: 0; }
 </style>


### PR DESCRIPTION
## Summary
Wenn ein Mangel einem Termin zugeordnet wird der Nachfolger hat, zeigt die App:
"Achtung: Dieser Mangel kann Folgegewerk [Maler] verzoegern."

- Dependencies werden parallel geladen
- Direkte Nachfolger des zugeordneten Termins berechnet
- Amber-farbige Warnung unter dem Termin-Selektor

## Test plan
- [ ] Mangel mit Termin verknuepfen der Nachfolger hat → Warnung sichtbar
- [ ] Mangel mit Termin ohne Nachfolger → keine Warnung
- [ ] Kein Termin zugeordnet → keine Warnung
- [ ] Mobile (375px): Warnung lesbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)