### PR TITLE
fix: Drag-Linie bei Verknuepfung startet exakt am Balken

### DIFF
--- a/src/lib/components/Gantt.svelte
+++ b/src/lib/components/Gantt.svelte
@@ -374,6 +374,8 @@
   }>(null);
   let depMode = $state<{ id: string; handle: DepHandle } | null>(null); // Touch-Mode
 
+  const AXIS_HEIGHT = 60; // Height of the gantt-axis header
+
   function onHandlePointerDown(e: PointerEvent, taskId: string, handle: DepHandle) {
     e.stopPropagation();
     if (!onDepCreate) return;
@@ -381,14 +383,15 @@
     const wrap = (e.currentTarget as HTMLElement).closest('.gantt-timeline');
     if (!wrap) return;
     const rect = wrap.getBoundingClientRect();
+    // Subtract AXIS_HEIGHT because the SVG overlay starts at top:60px
     depDrag = {
       predecessorId: taskId,
       predHandle: handle,
       pointerId: e.pointerId,
       cursorX: e.clientX - rect.left,
-      cursorY: e.clientY - rect.top,
+      cursorY: e.clientY - rect.top - AXIS_HEIGHT,
       startX: e.clientX - rect.left,
-      startY: e.clientY - rect.top
+      startY: e.clientY - rect.top - AXIS_HEIGHT
     };
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   }
@@ -397,7 +400,7 @@
     const wrap = (e.currentTarget as HTMLElement).closest('.gantt-timeline');
     if (!wrap) return;
     const rect = wrap.getBoundingClientRect();
-    depDrag = { ...depDrag, cursorX: e.clientX - rect.left, cursorY: e.clientY - rect.top };
+    depDrag = { ...depDrag, cursorX: e.clientX - rect.left, cursorY: e.clientY - rect.top - AXIS_HEIGHT };
   }
   function onHandlePointerUp(e: PointerEvent) {
     if (!depDrag || depDrag.pointerId !== e.pointerId) return;
@@ -474,7 +477,7 @@
   /** Pfad-Generator: rechteckige Polylinie zwischen zwei Punkten,
    * ähnlich MS-Project: vom predecessor-Edge nach rechts/links,
    * dann vertikal, dann zur successor-Bar. */
-  let diagonalDeps = $state(true); // Default: diagonal (natürlicher)
+  let diagonalDeps = $state(false); // Default: orthogonal (rechtwinklig)
 
   function depPath(d: Dependency): string | null {
     const pred = barEdges(d.predecessorId);


### PR DESCRIPTION
## Problem
Rote Drag-Linie beim Erstellen einer Verknuepfung erschien 60px unter dem Startpunkt und folgte dem Mauszeiger mit Offset.

## Ursache
SVG-Overlay hat `top: 60px` (Achsen-Hoehe), aber Pointer-Koordinaten wurden ab `top: 0` der Timeline berechnet → 60px Y-Versatz.

## Fix
- AXIS_HEIGHT (60px) von startY/cursorY subtrahiert
- Linie startet exakt am Dep-Handle und folgt dem Cursor 1:1
- Default zurueck auf orthogonale Pfeile (rechtwinklig)

## Test plan
- [ ] Dep-Handle am Balkenende greifen → rote Linie startet GENAU dort
- [ ] Maus bewegen → Linie folgt exakt dem Cursor
- [ ] Auf Ziel-Balken loslassen → Verknuepfung wird erstellt

🤖 Generated with [Claude Code](https://claude.com/claude-code)