### PR TITLE
design: Liquid Construction System tokens

### DIFF
--- a/reference/design/liquid-construction-system.md
+++ b/reference/design/liquid-construction-system.md
@@ -1,0 +1,181 @@
+---
+name: Liquid Construction System
+colors:
+  surface: '#f9f9fe'
+  surface-dim: '#d9dade'
+  surface-bright: '#f9f9fe'
+  surface-container-lowest: '#ffffff'
+  surface-container-low: '#f3f3f8'
+  surface-container: '#ededf2'
+  surface-container-high: '#e8e8ed'
+  surface-container-highest: '#e2e2e7'
+  on-surface: '#1a1c1f'
+  on-surface-variant: '#5d3f3d'
+  inverse-surface: '#2e3034'
+  inverse-on-surface: '#f0f0f5'
+  outline: '#926e6c'
+  outline-variant: '#e7bdb9'
+  surface-tint: '#c0001e'
+  primary: '#b7001c'
+  on-primary: '#ffffff'
+  primary-container: '#e2162a'
+  on-primary-container: '#fff7f6'
+  inverse-primary: '#ffb3ae'
+  secondary: '#5d5e5f'
+  on-secondary: '#ffffff'
+  secondary-container: '#e0dfe0'
+  on-secondary-container: '#626364'
+  tertiary: '#5a5a5a'
+  on-tertiary: '#ffffff'
+  tertiary-container: '#727272'
+  on-tertiary-container: '#f8f8f8'
+  error: '#ba1a1a'
+  on-error: '#ffffff'
+  error-container: '#ffdad6'
+  on-error-container: '#93000a'
+  primary-fixed: '#ffdad7'
+  primary-fixed-dim: '#ffb3ae'
+  on-primary-fixed: '#410004'
+  on-primary-fixed-variant: '#930014'
+  secondary-fixed: '#e3e2e3'
+  secondary-fixed-dim: '#c6c6c7'
+  on-secondary-fixed: '#1a1c1d'
+  on-secondary-fixed-variant: '#464748'
+  tertiary-fixed: '#e2e2e2'
+  tertiary-fixed-dim: '#c6c6c6'
+  on-tertiary-fixed: '#1b1b1b'
+  on-tertiary-fixed-variant: '#474747'
+  background: '#f9f9fe'
+  on-background: '#1a1c1f'
+  surface-variant: '#e2e2e7'
+typography:
+  nav-title:
+    fontFamily: Inter
+    fontSize: 17px
+    fontWeight: '600'
+    lineHeight: 22px
+    letterSpacing: -0.41px
+  large-title:
+    fontFamily: Inter
+    fontSize: 34px
+    fontWeight: '700'
+    lineHeight: 41px
+    letterSpacing: 0.37px
+  headline:
+    fontFamily: Inter
+    fontSize: 17px
+    fontWeight: '600'
+    lineHeight: 22px
+    letterSpacing: -0.41px
+  body:
+    fontFamily: Inter
+    fontSize: 17px
+    fontWeight: '400'
+    lineHeight: 22px
+    letterSpacing: -0.41px
+  callout:
+    fontFamily: Inter
+    fontSize: 16px
+    fontWeight: '400'
+    lineHeight: 21px
+    letterSpacing: -0.32px
+  subheadline:
+    fontFamily: Inter
+    fontSize: 15px
+    fontWeight: '400'
+    lineHeight: 20px
+    letterSpacing: -0.24px
+  footnote:
+    fontFamily: Inter
+    fontSize: 13px
+    fontWeight: '400'
+    lineHeight: 18px
+    letterSpacing: -0.08px
+  caption-caps:
+    fontFamily: Inter
+    fontSize: 12px
+    fontWeight: '500'
+    lineHeight: 16px
+    letterSpacing: 0.06px
+rounded:
+  sm: 0.25rem
+  DEFAULT: 0.5rem
+  md: 0.75rem
+  lg: 1rem
+  xl: 1.5rem
+  full: 9999px
+spacing:
+  margin-main: 16px
+  gutter: 12px
+  stack-sm: 4px
+  stack-md: 8px
+  stack-lg: 16px
+  stack-xl: 24px
+  safe-area-bottom: 34px
+---
+
+## Brand & Style
+
+This design system is engineered for the high-stakes environment of construction management, blending the precision of industrial engineering with the premium aesthetic of modern iOS interfaces. The brand personality is authoritative yet approachable, utilizing "Liquid Glass" effects to manage complex data density without overwhelming the user.
+
+The style is a sophisticated evolution of **Glassmorphism**, specifically tailored for professional utility. It relies on multi-layered translucency to establish a clear spatial mental model, allowing users to maintain context as they navigate through blueprints, schedules, and site reports. The visual language conveys transparency and structural integrity—core values in the construction industry.
+
+## Colors
+
+The palette is derived from the structural elements of a modern job site. **Construction Red (#E2162A)** serves as the primary action color, used sparingly for critical CTAs, status alerts, and brand touchpoints to ensure high visibility against architectural backdrops.
+
+**Dark Grey (#5B5C5D)** and **Black (#000000)** provide the foundation for typography and iconography, ensuring WCAG AA compliance. The background utilizes a soft iOS-style neutral grey to reduce eye strain during long site inspections. To achieve the "Liquid Glass" effect, the system employs semi-transparent white fills with high-saturation backdrop blurs, creating a sense of depth and hierarchy between the toolbars and the underlying content.
+
+## Typography
+
+This design system adopts the **Inter** font family for its exceptional legibility in varied lighting conditions found on construction sites. The typographic scale follows the iOS Human Interface Guidelines precisely, using dynamic Type sizes to ensure accessibility.
+
+The hierarchy is structured to prioritize legibility of technical data. Large titles are used for page-level navigation, while tight, medium-weight subheadlines are utilized for field labels and data values. Tracking (letter-spacing) is slightly tightened for larger headers and opened up for small captions to maintain a clean, high-fidelity appearance.
+
+## Layout & Spacing
+
+The layout philosophy is based on a **Fluid Grid** that respects iOS safe areas. A standard 16px lateral margin is maintained across all mobile views, with internal gutters set to 12px for card-based layouts.
+
+Spacing is applied using an 4px incremental scale to ensure vertical rhythm. In construction management views—such as Gantt charts or supply lists—the system allows for "Compact" density modes where padding is reduced to 8px to maximize information density. For standard management tasks, generous 16px padding within cards provides the necessary "breathing room" for the glass effects to be visible.
+
+## Elevation & Depth
+
+Depth in this design system is conveyed through **Backdrop Blurs** and **Ambient Shadows** rather than solid fills.
+
+1. **Base Layer:** The background is a solid light neutral grey.
+2. **Surface Layer (Cards):** Utilizes a subtle 20px blur with a white 70% opacity fill and a 0.5px inside stroke of pure white at 50% opacity to simulate a glass edge.
+3. **Floating Layer (Modals/Action Sheets):** Higher elevation is indicated by an increased blur radius (30px) and a soft, diffused shadow (`0px 10px 30px rgba(0,0,0,0.08)`).
+4. **Navigation:** The top Navigation Bar and bottom Tab Bar use a high-density "Material" blur (SystemUltraThin) that allows content to bleed through as it scrolls, maintaining the "Liquid" feel.
+
+## Shapes
+
+The shape language follows the **iOS Standard** for rounded rectangles (squircular appearance).
+
+- **Primary Container (Cards):** 12px corner radius.
+- **Buttons & Inputs:** 10px corner radius.
+- **Outer Modals:** 16-20px corner radius.
+- **Icon Enclosures:** 8px corner radius.
+
+Consistent roundness is critical to maintain the professional, high-fidelity feel. Elements are never sharp; even "small" UI components like tags or chips maintain a 6px minimum radius to align with the soft, glass-like aesthetic.
+
+## Components
+
+### Buttons
+Primary buttons use a solid **Construction Red (#E2162A)** fill with white text. Secondary buttons utilize the "Liquid Glass" effect: a translucent white background with a subtle border and dark grey text. Tap targets must be at least 44x44px.
+
+### Cards
+Cards are the primary container for site data. They feature a 12px radius, a 20px backdrop blur, and a 0.5px white border. Shadows are minimal, reserved for indicating that a card is "lifted" or draggable (e.g., reordering tasks).
+
+### Input Fields
+Inputs are styled as "Inset Groups." They feature a subtle grey background or a glass effect depending on the container. Labels are placed above the input in the `caption-caps` style for clarity.
+
+### Chips & Badges
+Used for status (e.g., "In Progress," "Delayed"). These use a lower opacity version of the status color with a high-contrast border and center-aligned text.
+
+### Segmented Controls
+Classic iOS-style controls used for switching between "List" and "Map" views. The selected segment is a solid white "glass" piece that appears to slide over the background track.
+
+### Construction-Specific Components
+- **Blueprint Viewer:** A full-screen modal with a light-to-dark toggle to improve visibility of CAD drawings.
+- **Punch List Items:** High-density rows with a checkbox on the left and a red "Action Required" indicator on the right.
+- **Daily Log Timeline:** A vertical track using the primary red color for the current time marker.

--- a/src/app.css
+++ b/src/app.css
@@ -2,19 +2,86 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Design tokens — ported 1:1 from reference/prototype.html */
+/* ============================================================
+   Liquid Construction System — Design Tokens
+   Source of truth: reference/design/liquid-construction-system.md
+   ============================================================ */
 :root {
-  --red: #E30613;
-  --red-deep: #B70510;
-  --red-soft: #FDECEE;
-  --ink: #0F0F10;
-  --ink-2: #2A2925;
-  --muted: #6B6660;
-  --line: rgba(15, 15, 16, 0.08);
-  --line-strong: rgba(15, 15, 16, 0.16);
-  --bg: #F6F4F1;
-  --paper: #FFFFFF;
-  --paper-tint: #FAF8F4;
+  /* --- Surface palette --- */
+  --surface: #f9f9fe;
+  --surface-dim: #d9dade;
+  --surface-bright: #f9f9fe;
+  --surface-container-lowest: #ffffff;
+  --surface-container-low: #f3f3f8;
+  --surface-container: #ededf2;
+  --surface-container-high: #e8e8ed;
+  --surface-container-highest: #e2e2e7;
+  --on-surface: #1a1c1f;
+  --on-surface-variant: #5d3f3d;
+  --inverse-surface: #2e3034;
+  --inverse-on-surface: #f0f0f5;
+  --surface-tint: #c0001e;
+  --surface-variant: #e2e2e7;
+
+  /* --- Primary (Construction Red) --- */
+  --primary: #b7001c;
+  --on-primary: #ffffff;
+  --primary-container: #e2162a;
+  --on-primary-container: #fff7f6;
+  --inverse-primary: #ffb3ae;
+
+  /* --- Secondary --- */
+  --secondary: #5d5e5f;
+  --on-secondary: #ffffff;
+  --secondary-container: #e0dfe0;
+  --on-secondary-container: #626364;
+
+  /* --- Tertiary --- */
+  --tertiary: #5a5a5a;
+  --on-tertiary: #ffffff;
+  --tertiary-container: #727272;
+  --on-tertiary-container: #f8f8f8;
+
+  /* --- Error --- */
+  --error: #ba1a1a;
+  --on-error: #ffffff;
+  --error-container: #ffdad6;
+  --on-error-container: #93000a;
+
+  /* --- Fixed variants --- */
+  --primary-fixed: #ffdad7;
+  --primary-fixed-dim: #ffb3ae;
+  --on-primary-fixed: #410004;
+  --on-primary-fixed-variant: #930014;
+  --secondary-fixed: #e3e2e3;
+  --secondary-fixed-dim: #c6c6c7;
+  --on-secondary-fixed: #1a1c1d;
+  --on-secondary-fixed-variant: #464748;
+  --tertiary-fixed: #e2e2e2;
+  --tertiary-fixed-dim: #c6c6c6;
+  --on-tertiary-fixed: #1b1b1b;
+  --on-tertiary-fixed-variant: #474747;
+
+  /* --- Outline --- */
+  --outline: #926e6c;
+  --outline-variant: #e7bdb9;
+
+  /* --- Background --- */
+  --background: #f9f9fe;
+  --on-background: #1a1c1f;
+
+  /* --- Legacy aliases (keep existing component CSS working) --- */
+  --red: var(--primary-container);       /* #E2162A */
+  --red-deep: var(--primary);            /* #B7001C */
+  --red-soft: var(--primary-fixed);      /* #FFDAD7 */
+  --ink: var(--on-surface);              /* #1A1C1F */
+  --ink-2: var(--on-surface-variant);    /* #5D3F3D */
+  --muted: var(--secondary);             /* #5D5E5F */
+  --line: var(--outline-variant);        /* #E7BDB9 */
+  --line-strong: var(--outline);         /* #926E6C */
+  --bg: var(--background);              /* #F9F9FE */
+  --paper: var(--surface-container-lowest); /* #FFFFFF */
+  --paper-tint: var(--surface-container-low); /* #F3F3F8 */
   --green: #2E7D32;
   --green-soft: #E8F4E9;
   --amber: #C97700;
@@ -22,17 +89,33 @@
   --blue: #1F4163;
   --blue-soft: #E5EBF1;
   --grey: #B5B0AB;
-  --grey-soft: #ECE9E4;
+  --grey-soft: var(--surface-container-highest); /* #E2E2E7 */
+
+  /* --- Shadows --- */
   --shadow-1: 0 1px 2px rgba(15, 15, 16, .04), 0 2px 6px rgba(15, 15, 16, .04);
   --shadow-2: 0 4px 12px rgba(15, 15, 16, .08), 0 12px 32px rgba(15, 15, 16, .06);
   --shadow-3: 0 24px 48px rgba(15, 15, 16, .18);
-  --r-sm: 6px;
-  --r-md: 10px;
-  --r-lg: 14px;
-  --r-xl: 20px;
-  --display: 'Archivo', system-ui, sans-serif;
+  --shadow-float: 0px 10px 30px rgba(0, 0, 0, 0.08);
+
+  /* --- Radii (Liquid Construction System) --- */
+  --r-sm: 0.25rem;   /* 4px */
+  --r-DEFAULT: 0.5rem; /* 8px */
+  --r-md: 0.75rem;   /* 12px — Cards */
+  --r-lg: 1rem;       /* 16px — Modals */
+  --r-xl: 1.5rem;     /* 24px */
+
+  /* --- Typography --- */
+  --display: 'Inter', system-ui, sans-serif;
   --body: 'Inter', system-ui, sans-serif;
   --mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  /* --- Spacing --- */
+  --margin-main: 16px;
+  --gutter: 12px;
+  --stack-sm: 4px;
+  --stack-md: 8px;
+  --stack-lg: 16px;
+  --stack-xl: 24px;
 
   /* ---------- Premium UX system (Phase B) ---------- */
   /* Easing curves (Apple-ish) */
@@ -113,10 +196,10 @@ html, body { margin: 0; padding: 0; }
 html { -webkit-text-size-adjust: 100%; }
 body {
   font-family: var(--body);
-  background: var(--bg);
-  color: var(--ink);
-  font-size: 15px;
-  line-height: 1.5;
+  background: var(--background);
+  color: var(--on-surface);
+  font-size: 17px;
+  line-height: 1.29; /* 22/17 — iOS body ratio */
   -webkit-font-smoothing: antialiased;
   min-height: 100dvh;
   overflow-x: hidden;
@@ -128,7 +211,7 @@ input:focus, textarea:focus, select:focus { outline: 2px solid var(--red); outli
 /* App shell */
 .app-shell { min-height: 100dvh; display: flex; flex-direction: column; }
 main { flex: 1; padding-bottom: 80px; }
-.page { padding: 14px; max-width: 1100px; margin: 0 auto; }
+.page { padding: var(--margin-main); max-width: 1100px; margin: 0 auto; }
 
 /* Topbar (glass) */
 .topbar {

--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-  <meta name="theme-color" content="#E30613" />
+  <meta name="theme-color" content="#E2162A" />
   <link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
   <link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,26 +1,108 @@
 import type { Config } from 'tailwindcss';
+import plugin from 'tailwindcss/plugin';
 
 export default {
   content: ['./src/**/*.{html,svelte,ts,js}'],
   theme: {
+    borderRadius: {
+      none: '0',
+      sm: '0.25rem',    /* 4px */
+      DEFAULT: '0.5rem', /* 8px */
+      md: '0.75rem',     /* 12px */
+      lg: '1rem',        /* 16px */
+      xl: '1.5rem',      /* 24px */
+      full: '9999px'
+    },
     extend: {
       colors: {
+        /* --- Liquid Construction System palette --- */
+        surface: {
+          DEFAULT: 'var(--surface)',
+          dim: 'var(--surface-dim)',
+          bright: 'var(--surface-bright)',
+          'container-lowest': 'var(--surface-container-lowest)',
+          'container-low': 'var(--surface-container-low)',
+          container: 'var(--surface-container)',
+          'container-high': 'var(--surface-container-high)',
+          'container-highest': 'var(--surface-container-highest)',
+          tint: 'var(--surface-tint)',
+          variant: 'var(--surface-variant)'
+        },
+        'on-surface': {
+          DEFAULT: 'var(--on-surface)',
+          variant: 'var(--on-surface-variant)'
+        },
+        'inverse-surface': 'var(--inverse-surface)',
+        'inverse-on-surface': 'var(--inverse-on-surface)',
+        primary: {
+          DEFAULT: 'var(--primary)',
+          container: 'var(--primary-container)',
+          fixed: 'var(--primary-fixed)',
+          'fixed-dim': 'var(--primary-fixed-dim)'
+        },
+        'on-primary': {
+          DEFAULT: 'var(--on-primary)',
+          container: 'var(--on-primary-container)',
+          fixed: 'var(--on-primary-fixed)',
+          'fixed-variant': 'var(--on-primary-fixed-variant)'
+        },
+        'inverse-primary': 'var(--inverse-primary)',
+        secondary: {
+          DEFAULT: 'var(--secondary)',
+          container: 'var(--secondary-container)',
+          fixed: 'var(--secondary-fixed)',
+          'fixed-dim': 'var(--secondary-fixed-dim)'
+        },
+        'on-secondary': {
+          DEFAULT: 'var(--on-secondary)',
+          container: 'var(--on-secondary-container)',
+          fixed: 'var(--on-secondary-fixed)',
+          'fixed-variant': 'var(--on-secondary-fixed-variant)'
+        },
+        tertiary: {
+          DEFAULT: 'var(--tertiary)',
+          container: 'var(--tertiary-container)',
+          fixed: 'var(--tertiary-fixed)',
+          'fixed-dim': 'var(--tertiary-fixed-dim)'
+        },
+        'on-tertiary': {
+          DEFAULT: 'var(--on-tertiary)',
+          container: 'var(--on-tertiary-container)',
+          fixed: 'var(--on-tertiary-fixed)',
+          'fixed-variant': 'var(--on-tertiary-fixed-variant)'
+        },
+        error: {
+          DEFAULT: 'var(--error)',
+          container: 'var(--error-container)'
+        },
+        'on-error': {
+          DEFAULT: 'var(--on-error)',
+          container: 'var(--on-error-container)'
+        },
+        outline: {
+          DEFAULT: 'var(--outline)',
+          variant: 'var(--outline-variant)'
+        },
+        background: 'var(--background)',
+        'on-background': 'var(--on-background)',
+
+        /* --- Legacy aliases (keep existing code working) --- */
         red: {
-          DEFAULT: '#E30613',
-          deep: '#B70510',
-          soft: '#FDECEE'
+          DEFAULT: 'var(--primary-container)', /* Construction Red #E2162A */
+          deep: 'var(--primary)',               /* #B7001C */
+          soft: 'var(--primary-fixed)'          /* #FFDAD7 */
         },
         ink: {
-          DEFAULT: '#0F0F10',
-          2: '#2A2925'
+          DEFAULT: 'var(--on-surface)',
+          2: 'var(--on-surface-variant)'
         },
-        muted: '#6B6660',
-        line: 'rgba(15,15,16,0.08)',
-        'line-strong': 'rgba(15,15,16,0.16)',
-        bg: '#F6F4F1',
+        muted: 'var(--secondary)',
+        line: 'var(--outline-variant)',
+        'line-strong': 'var(--outline)',
+        bg: 'var(--background)',
         paper: {
-          DEFAULT: '#FFFFFF',
-          tint: '#FAF8F4'
+          DEFAULT: 'var(--surface-container-lowest)',
+          tint: 'var(--surface-container-low)'
         },
         green: {
           DEFAULT: '#2E7D32',
@@ -36,26 +118,53 @@ export default {
         },
         grey: {
           DEFAULT: '#B5B0AB',
-          soft: '#ECE9E4'
+          soft: 'var(--surface-container-highest)'
         }
       },
       fontFamily: {
-        display: ['Archivo', 'system-ui', 'sans-serif'],
+        display: ['Inter', 'system-ui', 'sans-serif'],
         body: ['Inter', 'system-ui', 'sans-serif'],
         mono: ['JetBrains Mono', 'ui-monospace', 'monospace']
+      },
+      fontSize: {
+        'nav-title': ['17px', { lineHeight: '22px', letterSpacing: '-0.41px', fontWeight: '600' }],
+        'large-title': ['34px', { lineHeight: '41px', letterSpacing: '0.37px', fontWeight: '700' }],
+        headline: ['17px', { lineHeight: '22px', letterSpacing: '-0.41px', fontWeight: '600' }],
+        body: ['17px', { lineHeight: '22px', letterSpacing: '-0.41px', fontWeight: '400' }],
+        callout: ['16px', { lineHeight: '21px', letterSpacing: '-0.32px', fontWeight: '400' }],
+        subheadline: ['15px', { lineHeight: '20px', letterSpacing: '-0.24px', fontWeight: '400' }],
+        footnote: ['13px', { lineHeight: '18px', letterSpacing: '-0.08px', fontWeight: '400' }],
+        'caption-caps': ['12px', { lineHeight: '16px', letterSpacing: '0.06px', fontWeight: '500' }]
+      },
+      spacing: {
+        'margin-main': '16px',
+        gutter: '12px',
+        'stack-sm': '4px',
+        'stack-md': '8px',
+        'stack-lg': '16px',
+        'stack-xl': '24px',
+        'safe-area-bottom': '34px'
       },
       boxShadow: {
         '1': '0 1px 2px rgba(15,15,16,.04), 0 2px 6px rgba(15,15,16,.04)',
         '2': '0 4px 12px rgba(15,15,16,.08), 0 12px 32px rgba(15,15,16,.06)',
-        '3': '0 24px 48px rgba(15,15,16,.18)'
-      },
-      borderRadius: {
-        sm: '6px',
-        md: '10px',
-        lg: '14px',
-        xl: '20px'
+        '3': '0 24px 48px rgba(15,15,16,.18)',
+        'float': '0px 10px 30px rgba(0,0,0,0.08)'
       }
     }
   },
-  plugins: []
+  plugins: [
+    /* Typography utility plugin for caption-caps uppercase transform */
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        '.text-caption-caps': {
+          fontSize: '12px',
+          lineHeight: '16px',
+          letterSpacing: '0.06px',
+          fontWeight: '500',
+          textTransform: 'uppercase'
+        }
+      });
+    })
+  ]
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Migriert alle Design-Tokens auf das neue **Liquid Construction System** (Glassmorphism + iOS-inspiriert)
- Neue Material-3-Style Farbpalette mit Construction Red (#E2162A) als Brand-Farbe
- iOS HIG Typography-Skala (nav-title, large-title, headline, body, callout, subheadline, footnote, caption-caps)
- Display-Font von Archivo auf Inter umgestellt
- Aktualisierte Border-Radius-Tokens (4/8/12/16/24px statt 6/10/14/20px)
- Spacing-Tokens (margin-main, gutter, stack-sm/md/lg/xl)
- Legacy-Aliases erhalten Kompatibilität mit bestehenden Komponenten

## Rein optische Änderung
Keine Funktionen, Routen, oder Backend-Logik geändert. Alle 60 Tests grün.

## Test plan
- [ ] App startet ohne Fehler (`pnpm dev`)
- [ ] Farben sind auf der neuen Palette (kühles Grau statt warmes Beige)
- [ ] Typography-Utilities funktionieren (`text-headline`, `text-caption-caps`, etc.)
- [ ] Mobile 375px: Kein Layout-Bruch
- [ ] Alle 60 bestehenden Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)