### PR TITLE
design: chips & badges refactor (lower-opacity + border)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -478,40 +478,43 @@ main { flex: 1; padding-bottom: 80px; }
   color: var(--muted); text-transform: uppercase; letter-spacing: .05em;
 }
 
-/* Filter pills */
+/* Filter pills & Chips — lower-opacity bg + high-contrast border */
 .filter-bar {
-  display: flex; gap: 6px; overflow-x: auto;
-  margin-bottom: 12px; padding-bottom: 4px;
+  display: flex; gap: var(--stack-sm); overflow-x: auto;
+  margin-bottom: var(--gutter); padding-bottom: var(--stack-sm);
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
 }
 .filter-bar::-webkit-scrollbar { display: none; }
 .filter-pill {
   padding: 7px 13px;
-  background: var(--paper);
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  font-family: var(--mono); font-size: 11px; font-weight: 600;
-  color: var(--muted);
-  text-transform: uppercase; letter-spacing: .04em;
+  min-height: 36px;
+  background: var(--surface-container-low);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--r-full, 9999px);
+  font-size: 12px; line-height: 16px; font-weight: 500;
+  letter-spacing: 0.06px; text-transform: uppercase;
+  color: var(--secondary);
   white-space: nowrap;
   cursor: pointer;
+  transition: all var(--d-fast) var(--ease-out-expo);
 }
 .filter-pill:hover {
-  border-color: var(--ink); color: var(--ink);
+  border-color: var(--outline); color: var(--on-surface);
   transform: translateY(-1px);
   box-shadow: var(--shadow-1);
 }
 .filter-pill.active {
-  background: var(--ink); color: #fff; border-color: var(--ink);
+  background: var(--inverse-surface); color: var(--inverse-on-surface);
+  border-color: var(--inverse-surface);
   box-shadow: 0 4px 12px rgba(15, 15, 16, 0.15);
 }
 .filter-pill .badge {
   display: inline-block; margin-left: 6px;
-  padding: 1px 6px; background: rgba(255, 255, 255, .18); border-radius: 8px;
+  padding: 1px 6px; background: rgba(255, 255, 255, .18); border-radius: var(--r-DEFAULT);
   font-size: 10px;
 }
-.filter-pill:not(.active) .badge { background: var(--grey-soft); color: var(--ink); }
+.filter-pill:not(.active) .badge { background: var(--surface-container-highest); color: var(--on-surface); }
 
 /* Cards / Items — Glass Surface */
 .scope-group {

--- a/src/app.css
+++ b/src/app.css
@@ -250,9 +250,9 @@
     opacity: 0.45;
   }
   :focus-visible {
-    outline: 2px solid var(--red);
+    outline: 2px solid var(--primary-container);
     outline-offset: 2px;
-    border-radius: 6px;
+    border-radius: var(--r-sm);
   }
 }
 
@@ -271,7 +271,7 @@ body {
 }
 button { font-family: inherit; cursor: pointer; border: none; background: none; }
 input, textarea, select { font-family: inherit; font-size: inherit; color: inherit; }
-input:focus, textarea:focus, select:focus { outline: 2px solid var(--red); outline-offset: 1px; }
+input:focus, textarea:focus, select:focus { outline: 2px solid var(--primary-container); outline-offset: 1px; }
 
 /* App shell */
 .app-shell { min-height: 100dvh; display: flex; flex-direction: column; }
@@ -583,27 +583,33 @@ main { flex: 1; padding-bottom: 80px; }
   margin-top: 2px;
 }
 
-/* Form fields */
-.field { margin-bottom: 16px; }
+/* Form fields — Inset Group Style */
+.field { margin-bottom: var(--stack-lg); }
 .field-label {
-  display: block; font-family: var(--mono); font-size: 11px; font-weight: 600;
-  text-transform: uppercase; letter-spacing: .05em;
-  color: var(--muted); margin-bottom: 6px;
+  display: block;
+  font-size: 12px; line-height: 16px; letter-spacing: 0.06px; font-weight: 500;
+  text-transform: uppercase;
+  color: var(--secondary); margin-bottom: var(--stack-sm);
 }
 .field-input {
-  width: 100%; padding: 11px 14px;
-  border: 1px solid var(--line-strong); border-radius: var(--r-md);
-  background: var(--paper-tint); transition: all .15s;
+  width: 100%; padding: 11px var(--margin-main);
+  min-height: 44px;
+  border: 1px solid var(--outline-variant); border-radius: var(--r-md);
+  background: var(--surface-container-low);
+  transition: all var(--d-fast) var(--ease-out-expo);
 }
-.field-input:focus { background: var(--paper); border-color: var(--red); }
-.field-hint { font-size: 12px; color: var(--muted); margin-top: 4px; }
+.field-input:focus {
+  background: var(--surface-container-lowest);
+  border-color: var(--primary-container);
+}
+.field-hint { font-size: 13px; line-height: 18px; color: var(--secondary); margin-top: var(--stack-sm); }
 .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
 
 /* Stepper */
 .stepper {
-  display: flex; align-items: center; gap: 8px;
-  background: var(--paper-tint); border: 1px solid var(--line-strong);
-  border-radius: var(--r-md); padding: 4px; width: fit-content;
+  display: flex; align-items: center; gap: var(--stack-md);
+  background: var(--surface-container-low); border: 1px solid var(--outline-variant);
+  border-radius: var(--r-md); padding: var(--stack-sm); width: fit-content;
 }
 .stepper-btn {
   width: 44px; height: 44px;

--- a/src/lib/components/PinPreview.svelte
+++ b/src/lib/components/PinPreview.svelte
@@ -109,7 +109,7 @@
   .pin-preview-text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
   .pin-preview-id { font-family: var(--mono); font-size: 10px; font-weight: 700; color: var(--muted); }
   .pin-preview-title { font-family: var(--display); font-weight: 700; font-size: 13px; line-height: 1.2; }
-  .pin-preview-status { font-family: var(--mono); font-size: 9px; font-weight: 700; padding: 2px 6px; border-radius: 999px; align-self: flex-start; text-transform: uppercase; letter-spacing: .04em; }
+  .pin-preview-status { font-size: 12px; line-height: 16px; font-weight: 500; letter-spacing: 0.06px; padding: 2px 8px; border-radius: var(--r-sm); align-self: flex-start; text-transform: uppercase; }
   .pin-preview-img { width: 56px; height: 56px; border-radius: 8px; overflow: hidden; padding: 0; border: 1px solid var(--line); flex-shrink: 0; cursor: zoom-in; }
   .pin-preview-img img { width: 100%; height: 100%; object-fit: cover; display: block; }
   .pin-preview-actions { display: flex; gap: 4px; padding: 6px 10px 10px; position: relative; }
@@ -122,8 +122,8 @@
   }
   .menu-item { padding: 8px 12px; text-align: left; font-size: 13px; cursor: pointer; }
   .menu-item:hover { background: var(--paper-tint); }
-  .status-open, .status-reopened { background: var(--red-soft); color: var(--red); }
-  .status-sent, .status-acknowledged { background: var(--amber-soft); color: var(--amber); }
-  .status-resolved, .status-accepted { background: var(--green-soft); color: var(--green); }
-  .status-rejected { background: var(--grey-soft); color: var(--muted); }
+  .status-open, .status-reopened { background: rgba(226, 22, 42, 0.10); color: var(--primary-container); border: 1px solid rgba(226, 22, 42, 0.30); }
+  .status-sent, .status-acknowledged { background: rgba(201, 119, 0, 0.10); color: var(--amber); border: 1px solid rgba(201, 119, 0, 0.30); }
+  .status-resolved, .status-accepted { background: rgba(46, 125, 50, 0.10); color: var(--green); border: 1px solid rgba(46, 125, 50, 0.30); }
+  .status-rejected { background: var(--surface-container); color: var(--secondary); border: 1px solid var(--outline-variant); }
 </style>

--- a/src/lib/components/VorgangTimeline.svelte
+++ b/src/lib/components/VorgangTimeline.svelte
@@ -92,12 +92,12 @@
   .vorgang-item.tint-blue .vorgang-dot { background: var(--blue); }
   .vorgang-body { flex: 1; min-width: 0; }
   .vorgang-line1 { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
-  .vorgang-status { font-family: var(--mono); font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; padding: 2px 7px; border-radius: 999px; border: 1px solid var(--line); }
-  .vorgang-status.status-red { color: var(--red); background: var(--red-soft); border-color: rgba(227, 6, 19, 0.2); }
-  .vorgang-status.status-amber { color: var(--amber); background: var(--amber-soft); border-color: rgba(217, 119, 6, 0.2); }
-  .vorgang-status.status-green { color: var(--green); background: var(--green-soft); border-color: rgba(46, 125, 50, 0.2); }
-  .vorgang-status.status-blue { color: var(--blue); background: var(--blue-soft); border-color: rgba(59, 108, 196, 0.2); }
-  .vorgang-status.status-grey { color: var(--ink-2); background: var(--paper-tint); }
+  .vorgang-status { font-size: 12px; line-height: 16px; font-weight: 500; letter-spacing: 0.06px; text-transform: uppercase; padding: 2px 8px; border-radius: var(--r-sm); border: 1px solid var(--outline-variant); }
+  .vorgang-status.status-red { color: var(--primary-container); background: rgba(226, 22, 42, 0.10); border-color: rgba(226, 22, 42, 0.30); }
+  .vorgang-status.status-amber { color: var(--amber); background: rgba(201, 119, 0, 0.10); border-color: rgba(201, 119, 0, 0.30); }
+  .vorgang-status.status-green { color: var(--green); background: rgba(46, 125, 50, 0.10); border-color: rgba(46, 125, 50, 0.30); }
+  .vorgang-status.status-blue { color: var(--blue); background: rgba(31, 65, 99, 0.10); border-color: rgba(31, 65, 99, 0.30); }
+  .vorgang-status.status-grey { color: var(--secondary); background: var(--surface-container-low); }
   .vorgang-time { font-family: var(--mono); font-size: 10px; color: var(--muted); }
   .vorgang-text { font-size: 13px; color: var(--ink); margin-top: 4px; line-height: 1.4; }
   .vorgang-meta { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 4px; font-family: var(--mono); font-size: 10px; color: var(--muted); }

--- a/src/routes/(app)/[projectId]/bauzeitenplan/[taskId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/bauzeitenplan/[taskId]/+page.svelte
@@ -347,9 +347,9 @@
   .defect-link-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
   .defect-link-id { font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--muted); flex-shrink: 0; }
   .defect-link-title { flex: 1; min-width: 0; font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .defect-link-status { font-family: var(--mono); font-size: 9px; font-weight: 700; text-transform: uppercase; padding: 2px 8px; border-radius: 999px; flex-shrink: 0; }
-  .defect-link-status.status-open, .defect-link-status.status-reopened { background: var(--red-soft); color: var(--red); }
-  .defect-link-status.status-sent, .defect-link-status.status-acknowledged { background: var(--amber-soft); color: var(--amber); }
-  .defect-link-status.status-resolved, .defect-link-status.status-accepted { background: var(--green-soft); color: var(--green); }
-  .defect-link-status.status-rejected { background: var(--grey-soft); color: var(--muted); }
+  .defect-link-status { font-size: 12px; line-height: 16px; font-weight: 500; letter-spacing: 0.06px; text-transform: uppercase; padding: 2px 8px; border-radius: var(--r-sm); flex-shrink: 0; }
+  .defect-link-status.status-open, .defect-link-status.status-reopened { background: rgba(226, 22, 42, 0.10); color: var(--primary-container); border: 1px solid rgba(226, 22, 42, 0.30); }
+  .defect-link-status.status-sent, .defect-link-status.status-acknowledged { background: rgba(201, 119, 0, 0.10); color: var(--amber); border: 1px solid rgba(201, 119, 0, 0.30); }
+  .defect-link-status.status-resolved, .defect-link-status.status-accepted { background: rgba(46, 125, 50, 0.10); color: var(--green); border: 1px solid rgba(46, 125, 50, 0.30); }
+  .defect-link-status.status-rejected { background: var(--surface-container); color: var(--secondary); border: 1px solid var(--outline-variant); }
 </style>

--- a/src/routes/(app)/[projectId]/checklisten/[checklistId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/checklisten/[checklistId]/+page.svelte
@@ -238,8 +238,8 @@
   .checklist-num { flex-shrink: 0; width: 30px; height: 30px; background: var(--ink); color: #fff; border-radius: 8px; display: flex; align-items: center; justify-content: center; font-family: var(--display); font-weight: 800; font-size: 13px; }
   .filter-houses { display: flex; gap: 6px; overflow-x: auto; margin: 4px 0 14px; padding: 2px 0; scrollbar-width: none; }
   .filter-houses::-webkit-scrollbar { display: none; }
-  .house-chip { padding: 6px 12px; background: var(--paper); border: 1px solid var(--line); border-radius: 999px; font-family: var(--mono); font-size: 11px; font-weight: 600; color: var(--muted); white-space: nowrap; transition: all .12s; cursor: pointer; }
-  .house-chip.active { background: var(--ink); color: #fff; border-color: var(--ink); }
+  .house-chip { padding: 6px 12px; min-height: 36px; background: var(--surface-container-low); border: 1px solid var(--outline-variant); border-radius: 9999px; font-size: 12px; line-height: 16px; font-weight: 500; letter-spacing: 0.06px; text-transform: uppercase; color: var(--secondary); white-space: nowrap; transition: all var(--d-fast) var(--ease-out-expo); cursor: pointer; display: inline-flex; align-items: center; }
+  .house-chip.active { background: var(--inverse-surface); color: var(--inverse-on-surface); border-color: var(--inverse-surface); }
   .section-block { margin-bottom: 16px; }
   .section-heading { font-family: var(--display); font-weight: 700; font-size: 13px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 0 0 8px; padding: 0 4px; }
   .item-card { background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-lg); padding: 14px 16px; margin-bottom: 8px; transition: all .15s; box-shadow: var(--shadow-1); }

--- a/src/routes/(app)/[projectId]/maengel/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/+page.svelte
@@ -764,11 +764,11 @@ import { matchDefectFilter, groupDefects, type DefectFilterJson, type GroupKey, 
   .defect-num { font-family: var(--mono); font-size: 11px; font-weight: 700; color: var(--muted); flex-shrink: 0; }
   .defect-title { font-weight: 600; font-size: 14px; }
   .defect-line2 { font-family: var(--mono); font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; margin-top: 2px; display: flex; gap: 4px; flex-wrap: wrap; }
-  .defect-status { font-family: var(--mono); font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; padding: 4px 8px; border-radius: 999px; flex-shrink: 0; }
-  .status-open, .status-reopened { background: var(--red-soft); color: var(--red); }
-  .status-sent, .status-acknowledged { background: var(--amber-soft); color: var(--amber); }
-  .status-resolved, .status-accepted { background: var(--green-soft); color: var(--green); }
-  .status-rejected { background: var(--grey-soft); color: var(--muted); }
+  .defect-status { font-size: 12px; line-height: 16px; font-weight: 500; letter-spacing: 0.06px; text-transform: uppercase; padding: 4px 8px; border-radius: var(--r-sm); flex-shrink: 0; }
+  .status-open, .status-reopened { background: rgba(226, 22, 42, 0.10); color: var(--primary-container); border: 1px solid rgba(226, 22, 42, 0.30); }
+  .status-sent, .status-acknowledged { background: rgba(201, 119, 0, 0.10); color: var(--amber); border: 1px solid rgba(201, 119, 0, 0.30); }
+  .status-resolved, .status-accepted { background: rgba(46, 125, 50, 0.10); color: var(--green); border: 1px solid rgba(46, 125, 50, 0.30); }
+  .status-rejected { background: var(--surface-container); color: var(--secondary); border: 1px solid var(--outline-variant); }
   .group-header {
     position: sticky; top: 56px; z-index: 10;
     margin: 16px 0 6px; padding: 6px 12px;
@@ -782,10 +782,10 @@ import { matchDefectFilter, groupDefects, type DefectFilterJson, type GroupKey, 
     display: inline-flex; align-items: center; gap: 8px;
     width: fit-content;
   }
-  .group-header.status-open, .group-header.status-reopened { color: var(--red); }
+  .group-header.status-open, .group-header.status-reopened { color: var(--primary-container); }
   .group-header.status-sent, .group-header.status-acknowledged { color: var(--amber); }
   .group-header.status-resolved, .group-header.status-accepted { color: var(--green); }
-  .group-header.status-rejected { color: var(--muted); }
+  .group-header.status-rejected { color: var(--secondary); }
   .group-header .count { font-size: 10px; opacity: 0.7; }
   .defect-card.overdue { border-color: rgba(227, 6, 19, 0.3); background: linear-gradient(to right, var(--tint-red), var(--paper) 30%); }
   .defect-prio { font-family: var(--display); font-weight: 900; font-size: 18px; color: var(--red); width: 24px; text-align: center; flex-shrink: 0; }

--- a/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
+++ b/src/routes/(app)/[projectId]/maengel/[defectId]/+page.svelte
@@ -663,7 +663,7 @@
   }
   .defect-title-input { flex: 1; min-width: 200px; font-family: var(--display); font-weight: 800; font-size: 22px; line-height: 1.1; letter-spacing: -.015em; border: none; padding: 4px 0; background: transparent; }
   .defect-title-input:focus { border-bottom: 2px solid var(--red); outline: none; }
-  .status-pill { font-family: var(--mono); font-size: 10px; font-weight: 700; text-transform: uppercase; padding: 4px 10px; border-radius: 999px; }
+  .status-pill { font-size: 12px; line-height: 16px; font-weight: 500; letter-spacing: 0.06px; text-transform: uppercase; padding: 4px 10px; border-radius: var(--r-sm); }
   .status-actions { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 16px; }
   .vorgaenge-grid { display: grid; grid-template-columns: 1fr; gap: 12px; margin-bottom: 16px; }
   @media (min-width: 768px) { .vorgaenge-grid { grid-template-columns: 1fr 1fr; } }
@@ -684,10 +684,10 @@
   .photo-add-tile { aspect-ratio: 1; border: 2px dashed var(--line-strong); border-radius: var(--r-md); background: var(--paper-tint); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4px; color: var(--muted); transition: all .15s; cursor: pointer; }
   .photo-add-tile:hover { border-color: var(--red); color: var(--red); background: var(--red-soft); }
   .photo-add-tile span { font-family: var(--mono); font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; }
-  .status-open, .status-reopened { background: var(--red-soft); color: var(--red); }
-  .status-sent, .status-acknowledged { background: var(--amber-soft); color: var(--amber); }
-  .status-resolved, .status-accepted { background: var(--green-soft); color: var(--green); }
-  .status-rejected { background: var(--grey-soft); color: var(--muted); }
+  .status-open, .status-reopened { background: rgba(226, 22, 42, 0.10); color: var(--primary-container); border: 1px solid rgba(226, 22, 42, 0.30); }
+  .status-sent, .status-acknowledged { background: rgba(201, 119, 0, 0.10); color: var(--amber); border: 1px solid rgba(201, 119, 0, 0.30); }
+  .status-resolved, .status-accepted { background: rgba(46, 125, 50, 0.10); color: var(--green); border: 1px solid rgba(46, 125, 50, 0.30); }
+  .status-rejected { background: var(--surface-container); color: var(--secondary); border: 1px solid var(--outline-variant); }
   .task-link-card { display: flex; align-items: center; gap: 10px; padding: 10px 12px; margin-top: 8px; background: var(--paper); border: 1px solid var(--line); border-radius: var(--r-md); text-decoration: none; color: inherit; transition: all .12s; min-height: 44px; }
   .task-link-card:hover { border-color: var(--line-strong); box-shadow: var(--shadow-1); }
   .task-link-icon { font-size: 18px; flex-shrink: 0; }


### PR DESCRIPTION
## Summary
- **Filter Pills**: surface-container-low bg, outline-variant border, caption-caps
- **Status Badges**: 10% opacity Hintergrund + 30% opacity High-Contrast-Border
- **House-Chips**: Gleicher Stil wie Filter-Pills
- Konsistente border-radius: r-sm (4px) für Status-Chips, full für Pills
- caption-caps Typography (12px, 500, uppercase) für alle Chips

Geänderte Dateien: app.css, VorgangTimeline, PinPreview, Mängel-Liste/Detail, Checklisten-Detail, Bauzeit-Task-Detail

## Rein optische Änderung
Keine Funktionen geändert. Alle 60 Tests grün.

## Test plan
- [ ] Filter-Pills in Mängel-Liste korrekt dargestellt
- [ ] Status-Badges haben subtilen farbigen Border
- [ ] House-Chips in Checklisten funktionieren
- [ ] Aktive Zustände für alle Chip-Typen visuell korrekt
- [ ] Mobile 375px: Chips scrollen horizontal

🤖 Generated with [Claude Code](https://claude.com/claude-code)