### PR TITLE
design: navigation refactor (Material Blur)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -278,49 +278,52 @@ input:focus, textarea:focus, select:focus { outline: 2px solid var(--primary-con
 main { flex: 1; padding-bottom: 80px; }
 .page { padding: var(--margin-main); max-width: 1100px; margin: 0 auto; }
 
-/* Topbar (glass) */
+/* Topbar — Material Blur Navigation */
 .topbar {
   position: sticky; top: 0; z-index: 50;
-  background: var(--glass-dark); color: #fff;
-  -webkit-backdrop-filter: var(--blur-std);
-  backdrop-filter: var(--blur-std);
-  padding: 10px 14px;
-  display: flex; align-items: center; gap: 12px;
+  background: var(--glass-dark); color: var(--inverse-on-surface);
+  -webkit-backdrop-filter: var(--blur-nav);
+  backdrop-filter: var(--blur-nav);
+  padding: 10px var(--margin-main);
+  min-height: 44px;
+  display: flex; align-items: center; gap: var(--gutter);
   border-bottom: 1px solid rgba(255, 255, 255, .08);
 }
 @supports not (backdrop-filter: blur(1px)) {
-  .topbar { background: var(--ink); }
+  .topbar { background: var(--inverse-surface); }
 }
 .topbar-logo {
   width: 30px; height: 30px;
-  border: 2.5px solid var(--red); border-radius: 4px;
+  border: 2.5px solid var(--primary-container); border-radius: var(--r-sm);
   position: relative; flex-shrink: 0;
 }
 .topbar-logo::after {
   content: ''; position: absolute; right: 3px; bottom: 3px;
-  width: 6px; height: 6px; background: var(--red); border-radius: 50%;
+  width: 6px; height: 6px; background: var(--primary-container); border-radius: 50%;
 }
 .topbar-text { flex: 1; min-width: 0; }
 .topbar-brand {
-  font-family: var(--display); font-weight: 800;
+  font-family: var(--display); font-weight: 700;
   font-size: 13px; letter-spacing: .05em;
   text-transform: uppercase; line-height: 1;
 }
-.topbar-brand .hl { color: var(--red); }
+.topbar-brand .hl { color: var(--primary-container); }
 .topbar-project {
-  font-family: var(--mono); font-size: 11px;
+  font-size: 12px; line-height: 16px; font-weight: 500;
+  letter-spacing: 0.06px;
   color: rgba(255, 255, 255, .65);
-  text-transform: uppercase; letter-spacing: .04em;
-  margin-top: 4px; display: flex; gap: 6px; align-items: center;
+  text-transform: uppercase;
+  margin-top: var(--stack-sm); display: flex; gap: 6px; align-items: center;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .topbar-project .switch {
   cursor: pointer; color: rgba(255, 255, 255, .5);
   text-decoration: underline; text-underline-offset: 2px;
   background: none; border: none; font: inherit; padding: 0;
+  min-height: 44px; min-width: 44px; display: inline-flex; align-items: center;
 }
 .topbar-project .switch:hover { color: #fff; }
-.topbar-actions { display: flex; gap: 6px; position: relative; }
+.topbar-actions { display: flex; gap: var(--stack-sm); position: relative; }
 .icon-btn {
   width: 44px; height: 44px;
   background: rgba(255, 255, 255, .08);
@@ -333,22 +336,21 @@ main { flex: 1; padding-bottom: 80px; }
 .icon-btn:active { transform: scale(.96); }
 .icon-btn svg { width: 18px; height: 18px; }
 
-/* Tabbar (glass) */
+/* Tabbar — Material Blur Navigation */
 .tabbar {
   position: sticky; bottom: 0; z-index: 40;
-  background: var(--glass-light);
-  -webkit-backdrop-filter: var(--blur-std);
-  backdrop-filter: var(--blur-std);
-  border-top: 1px solid var(--line);
+  background: var(--glass-nav);
+  -webkit-backdrop-filter: var(--blur-nav);
+  backdrop-filter: var(--blur-nav);
+  border-top: 0.5px solid var(--outline-variant);
   display: flex; gap: 0;
   overflow-x: auto;
-  padding: 6px 6px calc(6px + env(safe-area-inset-bottom));
-  box-shadow: 0 -4px 16px rgba(15, 15, 16, .04);
+  padding: 6px 6px calc(6px + env(safe-area-inset-bottom, var(--safe-area-bottom)));
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
 }
 @supports not (backdrop-filter: blur(1px)) {
-  .tabbar { background: var(--paper); }
+  .tabbar { background: var(--surface-container-low); }
 }
 .tabbar::-webkit-scrollbar { display: none; }
 @media (min-width: 640px) {
@@ -356,24 +358,25 @@ main { flex: 1; padding-bottom: 80px; }
 }
 .tabbar-btn {
   flex: 0 0 auto;
-  min-width: 64px;
-  padding: 8px 4px;
-  display: flex; flex-direction: column; align-items: center; gap: 4px;
-  color: var(--muted); border-radius: 10px;
+  min-width: 64px; min-height: 44px;
+  padding: 6px 4px;
+  display: flex; flex-direction: column; align-items: center; gap: 2px;
+  color: var(--secondary); border-radius: var(--r-DEFAULT);
   text-decoration: none;
   position: relative;
+  transition: color var(--d-fast) var(--ease-out-expo);
 }
 .tabbar-btn svg {
-  width: 20px; height: 20px;
+  width: 22px; height: 22px;
   transition: transform var(--d-fast) var(--ease-spring);
 }
 .tabbar-btn span {
-  font-size: 10px; font-weight: 600;
-  font-family: var(--mono); letter-spacing: .02em; text-transform: uppercase;
+  font-size: 10px; font-weight: 500;
+  letter-spacing: 0.06px;
 }
-.tabbar-btn.active { background: var(--red-soft); }
+.tabbar-btn.active { background: rgba(226, 22, 42, 0.08); }
 .tabbar-btn.active svg { transform: translateY(-1px); }
-.tabbar-btn.active, .tabbar-btn.active span { color: var(--red); }
+.tabbar-btn.active, .tabbar-btn.active span { color: var(--primary-container); }
 .tabbar-btn:active svg { transform: scale(0.85); }
 
 /* Buttons — Liquid Construction System


### PR DESCRIPTION
## Summary
- **Topbar**: Material Blur Navigation, primary-container für Logo/Brand
- **Tabbar**: Helles transluzentes Glass (glass-nav), 0.5px subtiler Border
- **Active Tab**: Primary-Container Farbe mit 8% Red-Tint Hintergrund
- **Touch-Targets**: Alle Nav-Elemente min 44px
- **Safe-Area**: env(safe-area-inset-bottom) mit 34px Fallback
- Caption-caps Typography für Project-Label

## Rein optische Änderung
Keine Funktionen geändert. Alle 60 Tests grün.

## Test plan
- [ ] Topbar zeigt dunkles Glass mit Blur-Effekt
- [ ] Tabbar zeigt helles transluzentes Glass
- [ ] Aktiver Tab ist rot markiert
- [ ] Content scrollt unter Navigation durch (Blur-Effekt sichtbar)
- [ ] Mobile 375px: Nav passt, Touch-Targets 44px
- [ ] iOS Safari: Safe-Area-Inset für Notch

🤖 Generated with [Claude Code](https://claude.com/claude-code)