### PR TITLE
design: modals & action sheets (floating glass layer)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -629,7 +629,7 @@ main { flex: 1; padding-bottom: 80px; }
 .stepper-btn:disabled { opacity: .3; cursor: not-allowed; }
 .stepper-value { min-width: 50px; text-align: center; font-family: var(--display); font-weight: 800; font-size: 20px; line-height: 1; }
 
-/* Sheet (glass top) */
+/* Sheet — Floating Layer (30px blur, soft shadow) */
 .scrim {
   position: fixed; inset: 0; z-index: 100;
   background: rgba(15, 15, 16, .42);
@@ -642,52 +642,60 @@ main { flex: 1; padding-bottom: 80px; }
 .scrim.open { opacity: 1; pointer-events: auto; }
 .sheet {
   position: fixed; left: 0; right: 0; bottom: 0; z-index: 101;
-  background: var(--paper);
-  border-top-left-radius: 22px; border-top-right-radius: 22px;
-  box-shadow: var(--shadow-3);
+  background: var(--glass-modal);
+  -webkit-backdrop-filter: var(--blur-modal);
+  backdrop-filter: var(--blur-modal);
+  border: 0.5px solid rgba(255, 255, 255, 0.50);
+  border-bottom: none;
+  border-top-left-radius: var(--r-xl); border-top-right-radius: var(--r-xl);
+  box-shadow: var(--shadow-float);
   transform: translateY(100%);
   transition: transform var(--d-page) var(--ease-out-expo);
   max-height: 92dvh;
   display: flex; flex-direction: column;
   touch-action: pan-y;
 }
+@supports not (backdrop-filter: blur(1px)) {
+  .sheet { background: var(--surface-container-lowest); box-shadow: var(--shadow-3); }
+}
 .sheet.open { transform: translateY(0); }
 .sheet.dragging { transition: none; }
 .sheet-handle-area {
   flex-shrink: 0;
-  background: var(--glass-frost);
-  -webkit-backdrop-filter: var(--blur-strong);
-  backdrop-filter: var(--blur-strong);
-  border-top-left-radius: 22px; border-top-right-radius: 22px;
-  padding-top: 4px;
+  background: var(--glass-modal);
+  -webkit-backdrop-filter: var(--blur-modal);
+  backdrop-filter: var(--blur-modal);
+  border-top-left-radius: var(--r-xl); border-top-right-radius: var(--r-xl);
+  padding-top: var(--stack-sm);
   cursor: grab;
 }
 .sheet-handle-area:active { cursor: grabbing; }
 .sheet-handle {
   width: 40px; height: 4px;
-  background: var(--line-strong); border-radius: 2px;
+  background: var(--outline-variant); border-radius: 2px;
   margin: 10px auto 0;
 }
-.sheet-head { padding: 12px 18px 6px; display: flex; align-items: flex-start; gap: 12px; flex-shrink: 0; }
+.sheet-head { padding: var(--gutter) var(--margin-main) 6px; display: flex; align-items: flex-start; gap: var(--gutter); flex-shrink: 0; }
 .sheet-head-text { flex: 1; min-width: 0; }
 .sheet-eyebrow {
-  font-family: var(--mono); font-size: 11px; font-weight: 700;
-  color: var(--red); text-transform: uppercase; letter-spacing: .06em;
-  margin-bottom: 4px; line-height: 1.3;
+  font-size: 12px; line-height: 16px; font-weight: 500;
+  letter-spacing: 0.06px; text-transform: uppercase;
+  color: var(--primary-container);
+  margin-bottom: var(--stack-sm); line-height: 1.3;
 }
-.sheet-title { font-family: var(--display); font-weight: 700; font-size: 18px; line-height: 1.2; margin: 0; }
+.sheet-title { font-family: var(--display); font-weight: 700; font-size: 17px; line-height: 22px; letter-spacing: -0.41px; margin: 0; }
 .sheet-close {
   flex-shrink: 0; width: 44px; height: 44px;
   border-radius: 50%; background: var(--surface-container-highest);
   display: flex; align-items: center; justify-content: center; color: var(--on-surface);
 }
-.sheet-close:hover { background: var(--line-strong); }
+.sheet-close:hover { background: var(--surface-container-high); }
 .sheet-close svg { width: 18px; height: 18px; }
-.sheet-body { padding: 6px 18px 18px; overflow-y: auto; flex: 1; }
+.sheet-body { padding: 6px var(--margin-main) var(--margin-main); overflow-y: auto; flex: 1; }
 .sheet-foot {
-  padding: 12px 18px calc(18px + env(safe-area-inset-bottom));
-  border-top: 1px solid var(--line);
-  background: var(--paper); flex-shrink: 0;
+  padding: var(--gutter) var(--margin-main) calc(var(--margin-main) + env(safe-area-inset-bottom, var(--safe-area-bottom)));
+  border-top: 0.5px solid var(--outline-variant);
+  background: var(--surface-container-lowest); flex-shrink: 0;
 }
 
 /* Toast (glass) */
@@ -695,36 +703,46 @@ main { flex: 1; padding-bottom: 80px; }
   position: fixed; left: 50%; bottom: 90px;
   transform: translateX(-50%) translateY(20px) scale(0.9);
   background: var(--glass-dark);
-  -webkit-backdrop-filter: var(--blur-std);
-  backdrop-filter: var(--blur-std);
-  color: #fff;
-  padding: 10px 18px; border-radius: 999px;
-  font-size: 13px; font-weight: 500;
+  -webkit-backdrop-filter: var(--blur-modal);
+  backdrop-filter: var(--blur-modal);
+  color: var(--inverse-on-surface);
+  padding: 10px var(--margin-main); border-radius: 9999px;
+  font-size: 13px; line-height: 18px; font-weight: 500; letter-spacing: -0.08px;
   z-index: 300; opacity: 0;
   transition: all var(--d-std) var(--ease-out-expo);
-  box-shadow: var(--shadow-2); pointer-events: none;
+  box-shadow: var(--shadow-float); pointer-events: none;
   max-width: calc(100vw - 32px);
 }
 .toast.show { opacity: 1; transform: translateX(-50%) translateY(0) scale(1); }
-@supports not (backdrop-filter: blur(1px)) { .toast { background: var(--ink); } }
+@supports not (backdrop-filter: blur(1px)) { .toast { background: var(--inverse-surface); } }
 
 /* Empty state */
-.empty { text-align: center; padding: 36px 18px; color: var(--muted); }
-.empty-emoji { font-size: 32px; margin-bottom: 8px; }
-.empty-text { font-size: 14px; }
+.empty { text-align: center; padding: 36px var(--margin-main); color: var(--secondary); }
+.empty-emoji { font-size: 32px; margin-bottom: var(--stack-md); }
+.empty-text { font-size: 15px; line-height: 20px; }
 
-/* Dialog */
+/* Dialog — Floating Layer */
 .dialog {
   position: fixed; inset: 0; z-index: 250;
   background: rgba(15, 15, 16, .55);
-  display: none; align-items: center; justify-content: center; padding: 18px;
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  display: none; align-items: center; justify-content: center;
+  padding: var(--margin-main);
 }
 .dialog.open { display: flex; }
 .dialog-panel {
-  background: var(--paper); border-radius: var(--r-lg);
-  padding: 20px; max-width: 420px; width: 100%;
-  box-shadow: var(--shadow-3);
+  background: var(--glass-modal);
+  -webkit-backdrop-filter: var(--blur-modal);
+  backdrop-filter: var(--blur-modal);
+  border: 0.5px solid rgba(255, 255, 255, 0.50);
+  border-radius: var(--r-lg);
+  padding: var(--stack-xl); max-width: 420px; width: 100%;
+  box-shadow: var(--shadow-float);
 }
-.dialog-title { font-family: var(--display); font-weight: 700; font-size: 17px; margin: 0 0 8px; }
-.dialog-text { color: var(--muted); margin: 0 0 18px; font-size: 14px; }
-.dialog-actions { display: flex; gap: 8px; justify-content: flex-end; }
+@supports not (backdrop-filter: blur(1px)) {
+  .dialog-panel { background: var(--surface-container-lowest); box-shadow: var(--shadow-3); }
+}
+.dialog-title { font-family: var(--display); font-weight: 600; font-size: 17px; line-height: 22px; letter-spacing: -0.41px; margin: 0 0 var(--stack-md); }
+.dialog-text { color: var(--secondary); margin: 0 0 var(--margin-main); font-size: 15px; line-height: 20px; }
+.dialog-actions { display: flex; gap: var(--stack-md); justify-content: flex-end; }


### PR DESCRIPTION
## Summary
- **Sheet/Action-Sheet**: glass-modal (white/80) + 30px blur, 0.5px Glass-Edge-Border, shadow-float
- **Dialog**: Gleicher Glass-Modal-Effekt, Scrim mit 4px blur
- **Toast**: Aufgewerteter 30px blur, shadow-float
- **Empty State**: Secondary Farbe, Subheadline Typography
- Alle mit @supports Fallbacks für nicht-blur Browser

## Rein optische Änderung
Keine Funktionen geändert. Alle 60 Tests grün.

## Test plan
- [ ] Sheet öffnet mit Glass-Effekt (Content durchscheint)
- [ ] Dialog zeigt Glass-Modal mit verschwommenem Hintergrund
- [ ] Toast zeigt Blur-Effekt
- [ ] Sheet-Close-Button 44px Touch-Target
- [ ] Mobile 375px: Sheet/Dialog passen auf kleinen Screen
- [ ] Safe-Area für iOS-Notch in Sheet-Footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)