### PR TITLE
feat(projects): Projekt löschen mit Passwort-Bestätigung

### DIFF
--- a/src/routes/(app)/projects/+page.server.ts
+++ b/src/routes/(app)/projects/+page.server.ts
@@ -1,7 +1,8 @@
-import type { PageServerLoad } from './$types';
+import type { PageServerLoad, Actions } from './$types';
 import { db } from '$lib/db/client';
 import { projects, projectMembers, houses, apartments, tasks, checklistProgress } from '$lib/db/schema';
 import { eq, sql, and, desc, inArray } from 'drizzle-orm';
+import { fail } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ locals }) => {
   if (!db || !locals.user) return { projects: [] };
@@ -47,3 +48,33 @@ export const load: PageServerLoad = async ({ locals }) => {
 
   return { projects: enriched };
 };
+
+const DELETE_PASSWORD = 'hofmannhaus';
+
+export const actions = {
+  delete: async ({ request, locals }) => {
+    if (!locals.user || !db) return fail(401);
+
+    const fd = Object.fromEntries(await request.formData());
+    const projectId = String(fd.projectId ?? '');
+    const password = String(fd.password ?? '');
+
+    if (!projectId) return fail(400, { error: 'Projekt-ID fehlt.' });
+    if (password !== DELETE_PASSWORD) return fail(403, { error: 'Falsches Passwort.' });
+
+    // Verify user is owner of this project
+    const [membership] = await db
+      .select({ role: projectMembers.role })
+      .from(projectMembers)
+      .where(and(eq(projectMembers.projectId, projectId), eq(projectMembers.userId, locals.user.id)))
+      .limit(1);
+
+    if (!membership || membership.role !== 'owner') {
+      return fail(403, { error: 'Nur Projekt-Eigentümer können Projekte löschen.' });
+    }
+
+    await db.delete(projects).where(eq(projects.id, projectId));
+
+    return { deleted: true };
+  }
+} satisfies Actions;

--- a/src/routes/(app)/projects/+page.svelte
+++ b/src/routes/(app)/projects/+page.svelte
@@ -1,6 +1,40 @@
 <script lang="ts">
   import Icon from '$lib/components/Icon.svelte';
-  let { data } = $props();
+  import { enhance } from '$app/forms';
+  import { toast } from '$lib/components/Toast.svelte';
+
+  let { data, form } = $props();
+
+  let deleteTarget = $state<{ id: string; name: string } | null>(null);
+  let password = $state('');
+  let deleting = $state(false);
+  let error = $state('');
+
+  function openDeleteDialog(id: string, name: string, e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
+    deleteTarget = { id, name };
+    password = '';
+    error = '';
+  }
+
+  function closeDeleteDialog() {
+    deleteTarget = null;
+    password = '';
+    error = '';
+    deleting = false;
+  }
+
+  $effect(() => {
+    if (form?.error) {
+      error = form.error;
+      deleting = false;
+    }
+    if (form?.deleted) {
+      toast('Projekt gelöscht.');
+      closeDeleteDialog();
+    }
+  });
 </script>
 
 <svelte:head><title>Projekte · Hofmann Bauleiter</title></svelte:head>
@@ -26,6 +60,14 @@
             {#if p.taskCount > 0}<span><b>{p.taskCount}</b> Termine</span>{/if}
           </span>
         </span>
+        <button
+          type="button"
+          class="project-delete-btn"
+          title="Projekt löschen"
+          onclick={(e) => openDeleteDialog(p.id, p.name, e)}
+        >
+          <Icon name="delete" size={16} />
+        </button>
       </a>
     {/each}
 
@@ -44,6 +86,57 @@
   </form>
 </div>
 
+<!-- Delete Confirmation Dialog -->
+{#if deleteTarget}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="dialog open" onclick={closeDeleteDialog} onkeydown={(e) => e.key === 'Escape' && closeDeleteDialog()}>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div class="dialog-panel" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="Projekt löschen">
+      <h3 class="dialog-title">Projekt löschen</h3>
+      <p class="dialog-text">
+        <b>{deleteTarget.name}</b> wird unwiderruflich gelöscht — inklusive aller Häuser, Termine, Mängel und Fotos.
+      </p>
+
+      <form
+        method="POST"
+        action="?/delete"
+        use:enhance={() => {
+          deleting = true;
+          error = '';
+          return async ({ update }) => {
+            await update();
+          };
+        }}
+      >
+        <input type="hidden" name="projectId" value={deleteTarget.id} />
+
+        <div class="field">
+          <label class="field-label" for="delete-password">Passwort zur Bestätigung</label>
+          <input
+            id="delete-password"
+            class="field-input"
+            type="password"
+            name="password"
+            placeholder="Passwort eingeben"
+            autocomplete="off"
+            bind:value={password}
+          />
+          {#if error}
+            <p class="field-error">{error}</p>
+          {/if}
+        </div>
+
+        <div class="dialog-actions">
+          <button type="button" class="btn btn-ghost" onclick={closeDeleteDialog}>Abbrechen</button>
+          <button type="submit" class="btn btn-danger" disabled={!password || deleting}>
+            {#if deleting}Löscht…{:else}Endgültig löschen{/if}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}
+
 <style>
   .picker-screen { min-height: 100dvh; background: var(--bg); padding: 36px 18px 60px; }
   .picker-hero { text-align: center; margin-bottom: 28px; }
@@ -61,6 +154,7 @@
     text-align: left; width: 100%;
     color: inherit; text-decoration: none;
     box-shadow: var(--shadow-1); transition: all .15s; cursor: pointer;
+    position: relative;
   }
   .project-card:hover { transform: translateY(-2px); box-shadow: var(--shadow-2); border-color: var(--ink); }
   .project-card-icon { flex-shrink: 0; width: 46px; height: 46px; border-radius: 10px; background: var(--red-soft); color: var(--red); display: flex; align-items: center; justify-content: center; }
@@ -68,6 +162,17 @@
   .project-card-name { font-family: var(--display); font-weight: 700; font-size: 16px; letter-spacing: -.01em; line-height: 1.2; margin-bottom: 4px; display: block; }
   .project-card-meta { font-family: var(--mono); font-size: 11px; font-weight: 500; color: var(--muted); text-transform: uppercase; letter-spacing: .04em; display: flex; flex-wrap: wrap; gap: 4px 10px; }
   .project-card-meta b { color: var(--ink-2); font-weight: 700; }
+  .project-delete-btn {
+    flex-shrink: 0; width: 44px; height: 44px;
+    display: flex; align-items: center; justify-content: center;
+    border-radius: var(--r-DEFAULT); color: var(--muted);
+    opacity: 0; transition: all var(--d-fast) var(--ease-out-expo);
+  }
+  .project-card:hover .project-delete-btn { opacity: 1; }
+  .project-delete-btn:hover { color: var(--error); background: var(--error-container); }
+  @media (hover: none) {
+    .project-delete-btn { opacity: 0.6; }
+  }
   .picker-add {
     background: var(--paper); border: 2px dashed var(--line-strong);
     border-radius: var(--r-lg); padding: 16px;
@@ -76,4 +181,8 @@
     text-decoration: none; transition: all .15s;
   }
   .picker-add:hover { border-color: var(--red); color: var(--red); background: var(--red-soft); }
+  .field-error {
+    font-size: 13px; color: var(--error); margin-top: var(--stack-sm);
+    font-weight: 500;
+  }
 </style>


### PR DESCRIPTION
## Summary
- Lösch-Button auf jeder Projekt-Karte (erscheint bei Hover)
- Passwort-Popup: Nutzer muss "hofmannhaus" eingeben zur Bestätigung
- Server-seitig: nur Owner können löschen (+ RLS-Policy)
- CASCADE löscht alle Kind-Daten (Häuser, Termine, Mängel, Fotos)
- Toast-Benachrichtigung nach erfolgreichem Löschen

## Test plan
- [ ] Lösch-Icon erscheint bei Hover auf Projekt-Karte
- [ ] Klick öffnet Passwort-Dialog
- [ ] Falsches Passwort zeigt Fehlermeldung
- [ ] Richtiges Passwort "hofmannhaus" löscht Projekt
- [ ] Toast zeigt "Projekt gelöscht"
- [ ] Projekt verschwindet aus der Liste
- [ ] Mobile 375px: Lösch-Button sichtbar (Touch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)